### PR TITLE
Feature/active ride #32

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,6 +70,7 @@ dependencies {
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.material:material-icons-extended")
     implementation("androidx.navigation:navigation-compose:2.8.9")
     implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.7")

--- a/app/src/main/java/com/wheels/app/navigation/BottomNavItem.kt
+++ b/app/src/main/java/com/wheels/app/navigation/BottomNavItem.kt
@@ -1,14 +1,39 @@
 package com.wheels.app.navigation
 
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Navigation
+import androidx.compose.material.icons.outlined.NotificationsNone
+import androidx.compose.material.icons.outlined.Place
+import androidx.compose.ui.graphics.vector.ImageVector
+
 data class BottomNavItem(
     val label: String,
     val route: String,
-    val badgeCount: Int? = null
+    val icon: ImageVector,
+    val badgeCount: Int? = null,
+    val usesAvatar: Boolean = false
 )
 
 val wheelsBottomNavItems = listOf(
-    BottomNavItem(label = "Home", route = Destinations.Home.route),
-    BottomNavItem(label = "Mis Viajes", route = Destinations.Rides.route),
-    BottomNavItem(label = "Pagos", route = Destinations.Payments.route),
-    BottomNavItem(label = "Perfil", route = Destinations.Profile.route)
+    BottomNavItem(
+        label = "Home",
+        route = Destinations.Home.route,
+        icon = Icons.Outlined.Place
+    ),
+    BottomNavItem(
+        label = "Rides",
+        route = Destinations.Rides.route,
+        icon = Icons.Outlined.Navigation
+    ),
+    BottomNavItem(
+        label = "Alerts",
+        route = Destinations.Payments.route,
+        icon = Icons.Outlined.NotificationsNone
+    ),
+    BottomNavItem(
+        label = "Profile",
+        route = Destinations.Profile.route,
+        icon = Icons.Outlined.Place,
+        usesAvatar = true
+    )
 )

--- a/app/src/main/java/com/wheels/app/navigation/WheelsNavGraph.kt
+++ b/app/src/main/java/com/wheels/app/navigation/WheelsNavGraph.kt
@@ -1,11 +1,6 @@
 package com.wheels.app.navigation
 
-import androidx.compose.material3.Badge
-import androidx.compose.material3.BadgedBox
-import androidx.compose.material3.NavigationBar
-import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -15,6 +10,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.wheels.app.ui.components.WheelsBottomBar
 import com.wheels.app.ui.screens.home.HomeScreen
 import com.wheels.app.ui.screens.home.HomeViewModel
 import com.wheels.app.ui.screens.payments.PaymentsScreen
@@ -27,39 +23,28 @@ import com.wheels.app.ui.screens.rides.RidesViewModel
 @Composable
 fun WheelsNavGraph() {
     val navController = rememberNavController()
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentDestination = navBackStackEntry?.destination
+    val selectedRoute = currentDestination
+        ?.hierarchy
+        ?.mapNotNull { it.route }
+        ?.firstOrNull { route -> wheelsBottomNavItems.any { it.route == route } }
 
     Scaffold(
         bottomBar = {
-            NavigationBar {
-                val navBackStackEntry by navController.currentBackStackEntryAsState()
-                val currentDestination = navBackStackEntry?.destination
-
-                wheelsBottomNavItems.forEach { item ->
-                    val selected = currentDestination?.hierarchy?.any { it.route == item.route } == true
-                    NavigationBarItem(
-                        selected = selected,
-                        onClick = {
-                            navController.navigate(item.route) {
-                                popUpTo(navController.graph.findStartDestination().id) {
-                                    saveState = true
-                                }
-                                launchSingleTop = true
-                                restoreState = true
-                            }
-                        },
-                        icon = {
-                            if (item.badgeCount != null) {
-                                BadgedBox(badge = { Badge { Text(item.badgeCount.toString()) } }) {
-                                    Text(item.label.first().toString())
-                                }
-                            } else {
-                                Text(item.label.first().toString())
-                            }
-                        },
-                        label = { Text(item.label) }
-                    )
+            WheelsBottomBar(
+                items = wheelsBottomNavItems,
+                selectedRoute = selectedRoute,
+                onItemSelected = { item ->
+                    navController.navigate(item.route) {
+                        popUpTo(navController.graph.findStartDestination().id) {
+                            saveState = true
+                        }
+                        launchSingleTop = true
+                        restoreState = true
+                    }
                 }
-            }
+            )
         }
     ) { innerPadding ->
         NavHost(

--- a/app/src/main/java/com/wheels/app/ui/components/WheelsBottomBar.kt
+++ b/app/src/main/java/com/wheels/app/ui/components/WheelsBottomBar.kt
@@ -1,11 +1,157 @@
 package com.wheels.app.ui.components
 
-import androidx.compose.material3.NavigationBar
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.wheels.app.navigation.BottomNavItem
+import com.wheels.app.ui.theme.Border
+import com.wheels.app.ui.theme.PrimaryBlue
+import com.wheels.app.ui.theme.TextSecondary
+import com.wheels.app.ui.theme.WheelsSurface
 
 @Composable
-fun WheelsBottomBar(content: @Composable () -> Unit) {
-    NavigationBar {
-        content()
+fun WheelsBottomBar(
+    items: List<BottomNavItem>,
+    selectedRoute: String?,
+    onItemSelected: (BottomNavItem) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = WheelsSurface,
+        shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
+        border = BorderStroke(1.dp, Border)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp, vertical = 12.dp),
+            horizontalArrangement = Arrangement.SpaceAround,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            items.forEach { item ->
+                BottomBarItem(
+                    item = item,
+                    selected = item.route == selectedRoute,
+                    onClick = { onItemSelected(item) }
+                )
+            }
+        }
     }
+}
+
+@Composable
+private fun BottomBarItem(
+    item: BottomNavItem,
+    selected: Boolean,
+    onClick: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .clip(RoundedCornerShape(18.dp))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        when {
+            item.usesAvatar -> ProfileBubble(selected = selected)
+            selected -> SelectedIconBubble(item = item)
+            else -> InactiveIconBubble(item = item)
+        }
+
+        Text(
+            text = item.label,
+            color = if (selected) PrimaryBlue else TextSecondary,
+            fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal
+        )
+    }
+}
+
+@Composable
+private fun SelectedIconBubble(item: BottomNavItem) {
+    Surface(
+        modifier = Modifier.size(56.dp),
+        shape = CircleShape,
+        color = PrimaryBlue
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            BadgedIcon(item = item, selected = true)
+        }
+    }
+}
+
+@Composable
+private fun InactiveIconBubble(item: BottomNavItem) {
+    Box(
+        modifier = Modifier.size(56.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        BadgedIcon(item = item, selected = false)
+    }
+}
+
+@Composable
+private fun BadgedIcon(
+    item: BottomNavItem,
+    selected: Boolean
+) {
+    val iconContent: @Composable () -> Unit = {
+        Icon(
+            imageVector = item.icon,
+            contentDescription = item.label,
+            tint = if (selected) WheelsSurface else TextSecondary,
+            modifier = Modifier.size(28.dp)
+        )
+    }
+
+    if (item.badgeCount != null && item.badgeCount > 0) {
+        BadgedBox(
+            badge = {
+                Badge {
+                    Text(item.badgeCount.toString())
+                }
+            }
+        ) {
+            iconContent()
+        }
+    } else {
+        iconContent()
+    }
+}
+
+@Composable
+private fun ProfileBubble(selected: Boolean) {
+    val bubbleSize = if (selected) 56.dp else 48.dp
+    Box(
+        modifier = Modifier
+            .size(bubbleSize)
+            .clip(CircleShape)
+            .background(
+                brush = Brush.linearGradient(
+                    colors = listOf(PrimaryBlue.copy(alpha = 0.72f), PrimaryBlue)
+                )
+            )
+    )
 }

--- a/app/src/main/java/com/wheels/app/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/wheels/app/ui/screens/home/HomeScreen.kt
@@ -1,20 +1,67 @@
 package com.wheels.app.ui.screens.home
 
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CreditCard
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.Phone
+import androidx.compose.material.icons.filled.Place
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.outlined.ChatBubbleOutline
+import androidx.compose.material.icons.outlined.MyLocation
+import androidx.compose.material.icons.outlined.Navigation
+import androidx.compose.material.icons.outlined.Schedule
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.wheels.app.ui.components.WheelsTopBar
+import com.wheels.app.ui.theme.Border
+import com.wheels.app.ui.theme.ElectricGreen
+import com.wheels.app.ui.theme.PrimaryBlue
+import com.wheels.app.ui.theme.SecondaryBlue
+import com.wheels.app.ui.theme.TextSecondary
+import com.wheels.app.ui.theme.WheelsBackground
+import com.wheels.app.ui.theme.WheelsSurface
 
 @Composable
 fun HomeScreen(
@@ -23,32 +70,631 @@ fun HomeScreen(
 ) {
     val state by viewModel.uiState.collectAsState()
 
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.BottomEnd
+    ) {
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(WheelsBackground)
+                .padding(innerPadding),
+            contentPadding = PaddingValues(bottom = 104.dp)
+        ) {
+            item { HeaderSection(state) }
+            item { MapSection(state.activeRide) }
+            item { CurrentRideSection(state.activeRide) }
+            item {
+                Text(
+                    text = "Updates",
+                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
+                    color = TextSecondary,
+                    modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 12.dp)
+                )
+            }
+            items(state.updates) { update ->
+                UpdateCard(
+                    update = update,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)
+                )
+            }
+        }
+
+        QuickPayButton(
+            modifier = Modifier.padding(end = 20.dp, bottom = 88.dp)
+        )
+    }
+}
+
+@Composable
+private fun HeaderSection(state: HomeUiState) {
     Column(
         modifier = Modifier
-            .fillMaxSize()
-            .padding(innerPadding)
-            .padding(horizontal = 24.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Top
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(bottomStart = 24.dp, bottomEnd = 24.dp))
+            .background(Brush.linearGradient(listOf(PrimaryBlue, Color(0xFF2D5280))))
+            .padding(horizontal = 20.dp, vertical = 18.dp)
+            .padding(top = 20.dp)
     ) {
-        WheelsTopBar(title = "Wheels")
-        
-        Column(
-            modifier = Modifier.fillMaxSize(),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
         ) {
-            Text(
-                text = state.welcomeTitle,
-                style = MaterialTheme.typography.headlineMedium,
-                textAlign = TextAlign.Center
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Surface(shape = CircleShape, color = WheelsSurface.copy(alpha = 0.10f)) {
+                    IconButton(onClick = {}) {
+                        Icon(
+                            imageVector = Icons.Default.Menu,
+                            contentDescription = "Menu",
+                            tint = WheelsSurface
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.width(12.dp))
+                Column {
+                    Text(
+                        text = state.welcomeMessage,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = WheelsSurface.copy(alpha = 0.72f)
+                    )
+                    Text(
+                        text = state.userName,
+                        style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
+                        color = WheelsSurface
+                    )
+                }
+            }
+
+            Box(contentAlignment = Alignment.TopEnd) {
+                Surface(shape = CircleShape, color = WheelsSurface.copy(alpha = 0.10f)) {
+                    IconButton(onClick = {}) {
+                        Icon(
+                            imageVector = Icons.Default.Notifications,
+                            contentDescription = "Notifications",
+                            tint = WheelsSurface
+                        )
+                    }
+                }
+                Box(
+                    modifier = Modifier
+                        .offset(x = (-6).dp, y = 6.dp)
+                        .size(8.dp)
+                        .clip(CircleShape)
+                        .background(ElectricGreen)
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            state.quickStats.forEach { stat ->
+                StatChip(stat = stat, modifier = Modifier.weight(1f))
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatChip(
+    stat: HomeQuickStat,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .clip(RoundedCornerShape(16.dp))
+            .background(WheelsSurface.copy(alpha = 0.10f))
+            .padding(vertical = 12.dp, horizontal = 8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = stat.value,
+            style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
+            color = stat.accentColor ?: WheelsSurface
+        )
+        Text(
+            text = stat.label,
+            style = MaterialTheme.typography.bodySmall,
+            color = WheelsSurface.copy(alpha = 0.70f)
+        )
+    }
+}
+
+@Composable
+private fun MapSection(activeRide: ActiveRideUiModel) {
+    Card(
+        modifier = Modifier
+            .padding(horizontal = 16.dp)
+            .offset(y = (-12).dp)
+            .shadow(12.dp, RoundedCornerShape(20.dp)),
+        shape = RoundedCornerShape(20.dp),
+        colors = CardDefaults.cardColors(containerColor = WheelsSurface)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(260.dp)
+                .background(Brush.linearGradient(listOf(Color(0xFFE8F0F9), WheelsBackground)))
+        ) {
+            MapGridBackground()
+            RoutePath()
+            EtaBadge(
+                etaMinutes = activeRide.etaMinutes,
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .padding(16.dp)
             )
+            DriverMarker(modifier = Modifier.align(Alignment.Center))
+
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(start = 72.dp, bottom = 56.dp)
+                    .size(12.dp)
+                    .clip(CircleShape)
+                    .background(SecondaryBlue)
+                    .border(2.dp, WheelsSurface, CircleShape)
+            )
+
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(top = 54.dp, end = 76.dp)
+                    .size(18.dp)
+                    .clip(CircleShape)
+                    .background(PrimaryBlue)
+                    .border(2.dp, WheelsSurface, CircleShape),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Place,
+                    contentDescription = "Destination",
+                    tint = WheelsSurface,
+                    modifier = Modifier.size(12.dp)
+                )
+            }
+
+            Surface(
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(16.dp),
+                shape = CircleShape,
+                color = WheelsSurface,
+                shadowElevation = 8.dp
+            ) {
+                IconButton(onClick = {}) {
+                    Icon(
+                        imageVector = Icons.Outlined.MyLocation,
+                        contentDescription = "Center map",
+                        tint = PrimaryBlue
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MapGridBackground() {
+    Canvas(modifier = Modifier.fillMaxSize()) {
+        val gridColor = SecondaryBlue.copy(alpha = 0.18f)
+        val verticalStops = listOf(size.width * 0.25f, size.width * 0.5f, size.width * 0.75f)
+        val horizontalStops = listOf(size.height * 0.25f, size.height * 0.5f, size.height * 0.75f)
+
+        verticalStops.forEach { x ->
+            drawLine(gridColor, start = Offset(x, 0f), end = Offset(x, size.height), strokeWidth = 1f)
+        }
+        horizontalStops.forEach { y ->
+            drawLine(gridColor, start = Offset(0f, y), end = Offset(size.width, y), strokeWidth = 1f)
+        }
+    }
+}
+
+@Composable
+private fun RoutePath() {
+    Canvas(modifier = Modifier.fillMaxSize()) {
+        drawLine(
+            color = SecondaryBlue.copy(alpha = 0.60f),
+            start = Offset(size.width * 0.20f, size.height * 0.78f),
+            end = Offset(size.width * 0.82f, size.height * 0.22f),
+            strokeWidth = 8f,
+            cap = StrokeCap.Round,
+            pathEffect = PathEffect.dashPathEffect(floatArrayOf(18f, 10f))
+        )
+    }
+}
+
+@Composable
+private fun EtaBadge(
+    etaMinutes: Int,
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(24.dp),
+        color = WheelsSurface,
+        shadowElevation = 8.dp
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.Schedule,
+                contentDescription = "ETA",
+                tint = ElectricGreen,
+                modifier = Modifier.size(16.dp)
+            )
+            Spacer(modifier = Modifier.width(8.dp))
             Text(
-                text = state.welcomeSubtitle,
-                style = MaterialTheme.typography.bodyLarge,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.padding(top = 12.dp)
+                text = "$etaMinutes min away",
+                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+                color = PrimaryBlue
             )
         }
+    }
+}
+
+@Composable
+private fun DriverMarker(modifier: Modifier = Modifier) {
+    Box(modifier = modifier, contentAlignment = Alignment.Center) {
+        Box(
+            modifier = Modifier
+                .size(72.dp)
+                .clip(CircleShape)
+                .background(ElectricGreen.copy(alpha = 0.18f))
+        )
+        Surface(
+            modifier = Modifier.size(62.dp),
+            shape = CircleShape,
+            color = WheelsSurface,
+            border = BorderStroke(4.dp, ElectricGreen),
+            shadowElevation = 10.dp
+        ) {
+            Box(contentAlignment = Alignment.Center) {
+                Icon(
+                    imageVector = Icons.Outlined.Navigation,
+                    contentDescription = "Driver",
+                    tint = PrimaryBlue,
+                    modifier = Modifier.size(28.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CurrentRideSection(activeRide: ActiveRideUiModel) {
+    Card(
+        modifier = Modifier
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
+        colors = CardDefaults.cardColors(containerColor = WheelsSurface),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+    ) {
+        Column(modifier = Modifier.padding(20.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "Current Ride",
+                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
+                    color = PrimaryBlue
+                )
+                Surface(
+                    shape = RoundedCornerShape(999.dp),
+                    color = ElectricGreen.copy(alpha = 0.12f)
+                ) {
+                    Text(
+                        text = "Active",
+                        color = ElectricGreen,
+                        style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.Medium),
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Box(
+                    modifier = Modifier
+                        .size(56.dp)
+                        .clip(CircleShape)
+                        .background(Brush.linearGradient(listOf(Color(0xFF5B89C8), PrimaryBlue))),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = "CM",
+                        color = WheelsSurface,
+                        style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
+                    )
+                }
+
+                Spacer(modifier = Modifier.width(12.dp))
+
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = activeRide.driver,
+                        style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
+                        color = PrimaryBlue
+                    )
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector = Icons.Default.Star,
+                            contentDescription = "Rating",
+                            tint = Color(0xFFFFA726),
+                            modifier = Modifier.size(14.dp)
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            text = activeRide.rating,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = TextSecondary
+                        )
+                        Text(
+                            text = "  •  ${activeRide.carModel}",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = TextSecondary
+                        )
+                    }
+                    Text(
+                        text = activeRide.licensePlate,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = TextSecondary
+                    )
+                }
+
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    CircleActionButton(icon = Icons.Outlined.ChatBubbleOutline, contentDescription = "Chat")
+                    CircleActionButton(icon = Icons.Default.Phone, contentDescription = "Call")
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+            HorizontalDivider(color = Border)
+            Spacer(modifier = Modifier.height(16.dp))
+
+            RoutePoint(
+                title = "Pickup",
+                location = activeRide.pickupLocation,
+                leading = {
+                    Box(
+                        modifier = Modifier
+                            .padding(top = 8.dp)
+                            .size(8.dp)
+                            .clip(CircleShape)
+                            .background(SecondaryBlue)
+                    )
+                }
+            )
+
+            Box(
+                modifier = Modifier
+                    .padding(start = 3.dp, top = 4.dp, bottom = 4.dp)
+                    .height(18.dp)
+                    .border(1.dp, Border, RoundedCornerShape(2.dp))
+                    .width(0.dp)
+            )
+
+            RoutePoint(
+                title = "Destination",
+                location = activeRide.destination,
+                leading = {
+                    Icon(
+                        imageVector = Icons.Default.Place,
+                        contentDescription = "Destination",
+                        tint = PrimaryBlue,
+                        modifier = Modifier
+                            .padding(top = 2.dp)
+                            .size(16.dp)
+                    )
+                }
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "Trip Progress",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = TextSecondary
+                )
+                Text(
+                    text = "${activeRide.routeProgress}%",
+                    style = MaterialTheme.typography.bodySmall.copy(fontWeight = FontWeight.SemiBold),
+                    color = PrimaryBlue
+                )
+            }
+            Spacer(modifier = Modifier.height(6.dp))
+            ProgressBar(progress = activeRide.routeProgress / 100f)
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                DetailPill(title = "Distance", value = activeRide.distance, modifier = Modifier.weight(1f))
+                DetailPill(title = "Fare", value = activeRide.fare, modifier = Modifier.weight(1f))
+            }
+        }
+    }
+}
+
+@Composable
+private fun CircleActionButton(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    contentDescription: String
+) {
+    Surface(shape = CircleShape, color = Color(0xFFE8F0F9)) {
+        IconButton(onClick = {}) {
+            Icon(
+                imageVector = icon,
+                contentDescription = contentDescription,
+                tint = Color(0xFF5B89C8)
+            )
+        }
+    }
+}
+
+@Composable
+private fun RoutePoint(
+    title: String,
+    location: String,
+    leading: @Composable () -> Unit
+) {
+    Row(verticalAlignment = Alignment.Top) {
+        Box(modifier = Modifier.width(18.dp), contentAlignment = Alignment.TopCenter) {
+            leading()
+        }
+        Spacer(modifier = Modifier.width(10.dp))
+        Column {
+            Text(text = title, style = MaterialTheme.typography.bodySmall, color = TextSecondary)
+            Text(
+                text = location,
+                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
+                color = PrimaryBlue
+            )
+        }
+    }
+}
+
+@Composable
+private fun ProgressBar(progress: Float) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(8.dp)
+            .clip(RoundedCornerShape(999.dp))
+            .background(Color(0xFFE8F0F9))
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth(progress.coerceIn(0f, 1f))
+                .height(8.dp)
+                .background(Brush.horizontalGradient(listOf(Color(0xFF5B89C8), ElectricGreen)))
+        )
+    }
+}
+
+@Composable
+private fun DetailPill(
+    title: String,
+    value: String,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(WheelsBackground)
+            .padding(vertical = 14.dp, horizontal = 12.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(text = title, style = MaterialTheme.typography.bodySmall, color = TextSecondary)
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = value,
+            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
+            color = PrimaryBlue
+        )
+    }
+}
+
+@Composable
+private fun UpdateCard(
+    update: HomeUpdateUiModel,
+    modifier: Modifier = Modifier
+) {
+    val containerColor = when (update.tone) {
+        UpdateTone.Success -> ElectricGreen.copy(alpha = 0.10f)
+        UpdateTone.Info -> WheelsSurface
+    }
+    val borderColor = when (update.tone) {
+        UpdateTone.Success -> ElectricGreen.copy(alpha = 0.20f)
+        UpdateTone.Info -> Border
+    }
+    val iconBg = when (update.tone) {
+        UpdateTone.Success -> ElectricGreen
+        UpdateTone.Info -> SecondaryBlue.copy(alpha = 0.10f)
+    }
+    val iconTint = when (update.tone) {
+        UpdateTone.Success -> WheelsSurface
+        UpdateTone.Info -> SecondaryBlue
+    }
+    val icon = when (update.tone) {
+        UpdateTone.Success -> Icons.Outlined.Navigation
+        UpdateTone.Info -> Icons.Default.Star
+    }
+
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        color = containerColor,
+        border = BorderStroke(1.dp, borderColor)
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.Top
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(32.dp)
+                    .clip(CircleShape)
+                    .background(iconBg),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = iconTint,
+                    modifier = Modifier.size(16.dp)
+                )
+            }
+            Spacer(modifier = Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = update.title,
+                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
+                    color = PrimaryBlue
+                )
+                Text(
+                    text = update.description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = TextSecondary
+                )
+            }
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = update.timestamp,
+                style = MaterialTheme.typography.bodySmall,
+                color = TextSecondary
+            )
+        }
+    }
+}
+
+@Composable
+private fun QuickPayButton(modifier: Modifier = Modifier) {
+    Button(
+        onClick = {},
+        modifier = modifier,
+        shape = RoundedCornerShape(999.dp),
+        contentPadding = PaddingValues(horizontal = 18.dp, vertical = 12.dp)
+    ) {
+        Icon(
+            imageVector = Icons.Default.CreditCard,
+            contentDescription = null,
+            modifier = Modifier.size(16.dp)
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(text = "Quick Pay", style = MaterialTheme.typography.labelLarge)
     }
 }

--- a/app/src/main/java/com/wheels/app/ui/screens/home/HomeUiState.kt
+++ b/app/src/main/java/com/wheels/app/ui/screens/home/HomeUiState.kt
@@ -1,7 +1,60 @@
 package com.wheels.app.ui.screens.home
 
+import androidx.compose.ui.graphics.Color
+
 data class HomeUiState(
     val isLoading: Boolean = false,
-    val welcomeTitle: String = "Bienvenido a Wheels",
-    val welcomeSubtitle: String = "Busca, reserva y gestiona tus rides universitarios"
+    val userName: String = "Maria",
+    val welcomeMessage: String = "Welcome back",
+    val quickStats: List<HomeQuickStat> = listOf(
+        HomeQuickStat(label = "Rides", value = "12"),
+        HomeQuickStat(label = "Reliability", value = "98%", accentColor = Color(0xFF10B981)),
+        HomeQuickStat(label = "Rating", value = "5.0")
+    ),
+    val activeRide: ActiveRideUiModel = ActiveRideUiModel(),
+    val updates: List<HomeUpdateUiModel> = listOf(
+        HomeUpdateUiModel(
+            title = "Driver arriving soon",
+            description = "Carlos is 3 minutes away from pickup",
+            timestamp = "Now",
+            tone = UpdateTone.Success
+        ),
+        HomeUpdateUiModel(
+            title = "You earned punctuality points!",
+            description = "+5 points for being on time",
+            timestamp = "5m",
+            tone = UpdateTone.Info
+        )
+    )
 )
+
+data class HomeQuickStat(
+    val label: String,
+    val value: String,
+    val accentColor: Color? = null
+)
+
+data class ActiveRideUiModel(
+    val driver: String = "Carlos Mendez",
+    val rating: String = "4.8",
+    val carModel: String = "Toyota Corolla 2020",
+    val licensePlate: String = "ABC-123",
+    val pickupLocation: String = "Campus Uniandes - Entrance Gate",
+    val destination: String = "Centro Comercial Andino",
+    val etaMinutes: Int = 3,
+    val fare: String = "$3,500",
+    val distance: String = "4.2 km",
+    val routeProgress: Int = 45
+)
+
+data class HomeUpdateUiModel(
+    val title: String,
+    val description: String,
+    val timestamp: String,
+    val tone: UpdateTone
+)
+
+enum class UpdateTone {
+    Success,
+    Info
+}


### PR DESCRIPTION
This pull request introduces a new custom bottom navigation bar to the app, replacing the default Material3 navigation bar. It also updates the navigation item model to support icons and avatars, and enriches the `HomeUiState` with structured data for quick stats, active rides, and updates. The changes enhance both the visual appearance and the flexibility of the navigation and home screen UI.

**Navigation Bar Redesign:**

* Introduced a new `WheelsBottomBar` composable in `WheelsBottomBar.kt` to create a custom-styled bottom navigation bar, supporting icons, badges, and profile avatars. The bar uses custom theming and layout for improved UX.
* Updated `WheelsNavGraph.kt` to use the new `WheelsBottomBar` instead of the default `NavigationBar`, simplifying the navigation item selection logic and integrating the new model. [[1]](diffhunk://#diff-a92c559418652353f5a669b2f93d77717dce88ce955f897f3675a33f5403c824L3-L8) [[2]](diffhunk://#diff-a92c559418652353f5a669b2f93d77717dce88ce955f897f3675a33f5403c824R13) [[3]](diffhunk://#diff-a92c559418652353f5a669b2f93d77717dce88ce955f897f3675a33f5403c824L30-L63)

**Navigation Item Model Update:**

* Modified `BottomNavItem` to include an `icon` and `usesAvatar` property, and updated the list of navigation items to use icons and support avatars for the profile tab.
* Added the necessary dependency for extended Material icons in `build.gradle.kts`.

**Home Screen State Enhancements:**

* Refactored `HomeUiState` to include structured fields for user name, welcome message, quick stats, active ride details, and updates, along with new data classes for each section. This enables richer and more dynamic home screen content.