### PR TITLE
Implementation of group chat functionality

### DIFF
--- a/app/src/main/java/com/wheels/app/core/navigation/Destinations.kt
+++ b/app/src/main/java/com/wheels/app/core/navigation/Destinations.kt
@@ -5,5 +5,6 @@ sealed class Destinations(val route: String) {
     data object Rides : Destinations("rides")
     data object Payments : Destinations("payments")
     data object QuickPayment : Destinations("quick_payment")
+    data object GroupChat : Destinations("group_chat")
     data object Profile : Destinations("profile")
 }

--- a/app/src/main/java/com/wheels/app/core/navigation/WheelsNavGraph.kt
+++ b/app/src/main/java/com/wheels/app/core/navigation/WheelsNavGraph.kt
@@ -11,6 +11,8 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.wheels.app.core.ui.components.WheelsBottomBar
+import com.wheels.app.features.chat.presentation.ui.GroupChatScreen
+import com.wheels.app.features.chat.presentation.viewmodel.GroupChatViewModel
 import com.wheels.app.features.home.presentation.ui.HomeScreen
 import com.wheels.app.features.home.presentation.viewmodel.HomeViewModel
 import com.wheels.app.features.payments.presentation.ui.PaymentsScreen
@@ -30,11 +32,15 @@ fun WheelsNavGraph() {
         ?.hierarchy
         ?.mapNotNull { it.route }
         ?.firstOrNull { route -> wheelsBottomNavItems.any { it.route == route } }
-    val isQuickPaymentScreen = currentDestination?.route == Destinations.QuickPayment.route
+    val routeWithoutBottomBar = setOf(
+        Destinations.QuickPayment.route,
+        Destinations.GroupChat.route
+    )
+    val shouldShowBottomBar = currentDestination?.route !in routeWithoutBottomBar
 
     Scaffold(
         bottomBar = {
-            if (!isQuickPaymentScreen) {
+            if (shouldShowBottomBar) {
                 WheelsBottomBar(
                     items = wheelsBottomNavItems,
                     selectedRoute = selectedRoute,
@@ -70,6 +76,14 @@ fun WheelsNavGraph() {
             composable(Destinations.QuickPayment.route) {
                 val viewModel: PaymentsViewModel = hiltViewModel()
                 QuickPaymentScreen(innerPadding = innerPadding, navController = navController, viewModel = viewModel)
+            }
+            composable(Destinations.GroupChat.route) {
+                val viewModel: GroupChatViewModel = hiltViewModel()
+                GroupChatScreen(
+                    innerPadding = innerPadding,
+                    navController = navController,
+                    viewModel = viewModel
+                )
             }
             composable(Destinations.Profile.route) {
                 val viewModel: ProfileViewModel = hiltViewModel()

--- a/app/src/main/java/com/wheels/app/features/chat/presentation/ui/GroupChatScreen.kt
+++ b/app/src/main/java/com/wheels/app/features/chat/presentation/ui/GroupChatScreen.kt
@@ -1,0 +1,227 @@
+package com.wheels.app.features.chat.presentation.ui
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.wheels.app.core.ui.theme.Border
+import com.wheels.app.core.ui.theme.PrimaryBlue
+import com.wheels.app.core.ui.theme.SecondaryBlue
+import com.wheels.app.core.ui.theme.TextSecondary
+import com.wheels.app.core.ui.theme.WheelsBackground
+import com.wheels.app.core.ui.theme.WheelsSurface
+import com.wheels.app.features.chat.presentation.viewmodel.ChatMessageUiModel
+import com.wheels.app.features.chat.presentation.viewmodel.GroupChatEvent
+import com.wheels.app.features.chat.presentation.viewmodel.GroupChatUiState
+import com.wheels.app.features.chat.presentation.viewmodel.GroupChatViewModel
+
+@Composable
+fun GroupChatScreen(
+    innerPadding: PaddingValues,
+    navController: NavController,
+    viewModel: GroupChatViewModel
+) {
+    val state by viewModel.uiState.collectAsState()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(WheelsBackground)
+            .padding(innerPadding)
+            .navigationBarsPadding()
+            .imePadding()
+    ) {
+        GroupChatTopBar(
+            state = state,
+            onBack = { navController.popBackStack() },
+            onClose = { navController.popBackStack() }
+        )
+
+        LazyColumn(
+            modifier = Modifier.weight(1f),
+            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            items(state.messages, key = { it.id }) { message ->
+                ChatBubble(message = message)
+            }
+        }
+
+        MessageComposer(
+            value = state.draftMessage,
+            onValueChanged = { viewModel.onEvent(GroupChatEvent.DraftChanged(it)) },
+            onSend = { viewModel.onEvent(GroupChatEvent.SendMessage) }
+        )
+    }
+}
+
+@Composable
+private fun GroupChatTopBar(
+    state: GroupChatUiState,
+    onBack: () -> Unit,
+    onClose: () -> Unit
+) {
+    Surface(
+        color = WheelsSurface,
+        shadowElevation = 8.dp
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = onBack) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = "Back",
+                    tint = PrimaryBlue
+                )
+            }
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = state.title,
+                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
+                    color = PrimaryBlue
+                )
+                Text(
+                    text = "${state.tripLabel} · ${state.participantsLabel}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = TextSecondary
+                )
+            }
+
+            IconButton(onClick = onClose) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = "Close",
+                    tint = TextSecondary
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChatBubble(message: ChatMessageUiModel) {
+    val alignment = if (message.isCurrentUser) Alignment.CenterEnd else Alignment.CenterStart
+    val bubbleColor = if (message.isCurrentUser) PrimaryBlue else WheelsSurface
+    val contentColor = if (message.isCurrentUser) WheelsSurface else PrimaryBlue
+
+    Box(
+        modifier = Modifier.fillMaxWidth(),
+        contentAlignment = alignment
+    ) {
+        Card(
+            modifier = Modifier.fillMaxWidth(0.82f),
+            shape = RoundedCornerShape(22.dp),
+            colors = CardDefaults.cardColors(containerColor = bubbleColor),
+            border = if (message.isCurrentUser) null else BorderStroke(1.dp, Border)
+        ) {
+            Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)) {
+                Text(
+                    text = message.senderName,
+                    style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.SemiBold),
+                    color = if (message.isCurrentUser) WheelsSurface.copy(alpha = 0.82f) else SecondaryBlue
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = message.content,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = contentColor
+                )
+                Spacer(modifier = Modifier.height(6.dp))
+                Text(
+                    text = message.timestamp,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (message.isCurrentUser) WheelsSurface.copy(alpha = 0.72f) else TextSecondary,
+                    modifier = Modifier.fillMaxWidth(),
+                    textAlign = TextAlign.End
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MessageComposer(
+    value: String,
+    onValueChanged: (String) -> Unit,
+    onSend: () -> Unit
+) {
+    Surface(
+        color = WheelsSurface,
+        shadowElevation = 12.dp
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 14.dp),
+            verticalAlignment = Alignment.Bottom
+        ) {
+            OutlinedTextField(
+                value = value,
+                onValueChange = onValueChanged,
+                modifier = Modifier.weight(1f),
+                placeholder = {
+                    Text("Escribe un mensaje al grupo")
+                },
+                shape = RoundedCornerShape(18.dp),
+                maxLines = 4
+            )
+
+            Spacer(modifier = Modifier.size(12.dp))
+
+            Surface(
+                modifier = Modifier.size(52.dp),
+                shape = CircleShape,
+                color = PrimaryBlue
+            ) {
+                IconButton(onClick = onSend) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.Send,
+                        contentDescription = "Send",
+                        tint = WheelsSurface
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/wheels/app/features/chat/presentation/viewmodel/GroupChatViewModel.kt
+++ b/app/src/main/java/com/wheels/app/features/chat/presentation/viewmodel/GroupChatViewModel.kt
@@ -1,0 +1,99 @@
+package com.wheels.app.features.chat.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+
+@HiltViewModel
+class GroupChatViewModel @Inject constructor() : ViewModel() {
+
+    private val _uiState = MutableStateFlow(
+        GroupChatUiState(
+            participantsLabel = "Carlos + Laura + Mateo + Juliana",
+            messages = listOf(
+                ChatMessageUiModel(
+                    id = "1",
+                    senderName = "Carlos",
+                    content = "Hola equipo, ya voy saliendo de la porteria de Uniandes.",
+                    timestamp = "8:12 PM",
+                    isCurrentUser = false
+                ),
+                ChatMessageUiModel(
+                    id = "2",
+                    senderName = "Laura",
+                    content = "Perfecto, yo ya estoy en la entrada principal.",
+                    timestamp = "8:13 PM",
+                    isCurrentUser = false
+                ),
+                ChatMessageUiModel(
+                    id = "3",
+                    senderName = "Tú",
+                    content = "Voy en 2 minutos, gracias por esperar.",
+                    timestamp = "8:14 PM",
+                    isCurrentUser = true
+                ),
+                ChatMessageUiModel(
+                    id = "4",
+                    senderName = "Mateo",
+                    content = "Yo también ya estoy bajando.",
+                    timestamp = "8:15 PM",
+                    isCurrentUser = false
+                )
+            )
+        )
+    )
+    val uiState: StateFlow<GroupChatUiState> = _uiState.asStateFlow()
+
+    fun onEvent(event: GroupChatEvent) {
+        when (event) {
+            is GroupChatEvent.DraftChanged -> {
+                _uiState.update { it.copy(draftMessage = event.value) }
+            }
+
+            GroupChatEvent.SendMessage -> sendMessage()
+        }
+    }
+
+    private fun sendMessage() {
+        val newMessage = _uiState.value.draftMessage.trim()
+        if (newMessage.isEmpty()) return
+
+        _uiState.update { state ->
+            state.copy(
+                draftMessage = "",
+                messages = state.messages + ChatMessageUiModel(
+                    id = (state.messages.size + 1).toString(),
+                    senderName = "Tú",
+                    content = newMessage,
+                    timestamp = "Ahora",
+                    isCurrentUser = true
+                )
+            )
+        }
+    }
+}
+
+sealed interface GroupChatEvent {
+    data class DraftChanged(val value: String) : GroupChatEvent
+    data object SendMessage : GroupChatEvent
+}
+
+data class GroupChatUiState(
+    val title: String = "Ride Group Chat",
+    val tripLabel: String = "Campus Uniandes -> Centro Andino",
+    val participantsLabel: String,
+    val draftMessage: String = "",
+    val messages: List<ChatMessageUiModel> = emptyList()
+)
+
+data class ChatMessageUiModel(
+    val id: String,
+    val senderName: String,
+    val content: String,
+    val timestamp: String,
+    val isCurrentUser: Boolean
+)

--- a/app/src/main/java/com/wheels/app/features/home/presentation/ui/HomeScreen.kt
+++ b/app/src/main/java/com/wheels/app/features/home/presentation/ui/HomeScreen.kt
@@ -92,7 +92,12 @@ fun HomeScreen(
         ) {
             item { HeaderSection(state) }
             item { MapSection(state.activeRide) }
-            item { CurrentRideSection(state.activeRide) }
+            item {
+                CurrentRideSection(
+                    activeRide = state.activeRide,
+                    onOpenChat = { navController.navigate(Destinations.GroupChat.route) }
+                )
+            }
             item {
                 Text(
                     text = "Updates",
@@ -372,7 +377,10 @@ private fun DriverMarker(modifier: Modifier = Modifier) {
 }
 
 @Composable
-private fun CurrentRideSection(activeRide: ActiveRideUiModel) {
+private fun CurrentRideSection(
+    activeRide: ActiveRideUiModel,
+    onOpenChat: () -> Unit
+) {
     Card(
         modifier = Modifier
             .padding(horizontal = 16.dp, vertical = 4.dp)
@@ -445,7 +453,11 @@ private fun CurrentRideSection(activeRide: ActiveRideUiModel) {
                 }
 
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    CircleActionButton(icon = Icons.Outlined.ChatBubbleOutline, contentDescription = "Chat")
+                    CircleActionButton(
+                        icon = Icons.Outlined.ChatBubbleOutline,
+                        contentDescription = "Chat",
+                        onClick = onOpenChat
+                    )
                     CircleActionButton(icon = Icons.Default.Phone, contentDescription = "Call")
                 }
             }
@@ -515,9 +527,13 @@ private fun CurrentRideSection(activeRide: ActiveRideUiModel) {
 }
 
 @Composable
-private fun CircleActionButton(icon: androidx.compose.ui.graphics.vector.ImageVector, contentDescription: String) {
+private fun CircleActionButton(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    contentDescription: String,
+    onClick: () -> Unit = {}
+) {
     Surface(shape = CircleShape, color = Color(0xFFE8F0F9)) {
-        IconButton(onClick = {}) {
+        IconButton(onClick = onClick) {
             Icon(imageVector = icon, contentDescription = contentDescription, tint = Color(0xFF5B89C8))
         }
     }


### PR DESCRIPTION
This pull request introduces a new group chat feature for ride participants, integrating it into the app's navigation and UI. The main changes include adding the `GroupChatScreen` and its supporting ViewModel, updating the navigation graph to support the new screen, and providing access to the group chat from the current ride section in the home screen.

**Group Chat Feature Integration:**

* Added a new `GroupChatScreen` composable, which displays group chat messages, a message composer, and a custom top bar. This screen is connected to a new `GroupChatViewModel` that manages chat state and events. (`app/src/main/java/com/wheels/app/features/chat/presentation/ui/GroupChatScreen.kt`, `app/src/main/java/com/wheels/app/features/chat/presentation/viewmodel/GroupChatViewModel.kt`) [[1]](diffhunk://#diff-553aa700ce41d6c0536e656631c15c845cdc933c97428d2d424a6be175282ab5R1-R227) [[2]](diffhunk://#diff-af21c6f0e45a4b2969f01d312afc1698c8cea62e6618caaf9c234c7099c093c5R1-R99)
* Introduced the `GroupChat` destination in the sealed `Destinations` class to support navigation to the group chat screen. (`app/src/main/java/com/wheels/app/core/navigation/Destinations.kt`)
* Updated the navigation graph to include the new group chat route and ensure the bottom navigation bar is hidden on the group chat screen. (`app/src/main/java/com/wheels/app/core/navigation/WheelsNavGraph.kt`) [[1]](diffhunk://#diff-06a3c6f74e8eb6248b52f19d368fbafc40a28d5b925a27faf1d0fa6b8d4a0407R14-R15) [[2]](diffhunk://#diff-06a3c6f74e8eb6248b52f19d368fbafc40a28d5b925a27faf1d0fa6b8d4a0407L33-R43) [[3]](diffhunk://#diff-06a3c6f74e8eb6248b52f19d368fbafc40a28d5b925a27faf1d0fa6b8d4a0407R80-R87)

**Home Screen Enhancements:**

* Modified the `CurrentRideSection` to include a chat button. Pressing this button navigates to the group chat screen. The `CircleActionButton` composable was updated to accept an `onClick` callback. (`app/src/main/java/com/wheels/app/features/home/presentation/ui/HomeScreen.kt`) [[1]](diffhunk://#diff-6933e8143e1fe498e6d134f4e0a3f7c69dd8c452da89e8d3eaf7f9864636fca9L95-R100) [[2]](diffhunk://#diff-6933e8143e1fe498e6d134f4e0a3f7c69dd8c452da89e8d3eaf7f9864636fca9L375-R383) [[3]](diffhunk://#diff-6933e8143e1fe498e6d134f4e0a3f7c69dd8c452da89e8d3eaf7f9864636fca9L448-R460) [[4]](diffhunk://#diff-6933e8143e1fe498e6d134f4e0a3f7c69dd8c452da89e8d3eaf7f9864636fca9L518-R536)