### PR TITLE
Feature/reviews view #18

### DIFF
--- a/app/src/main/java/com/wheels/app/core/navigation/Destinations.kt
+++ b/app/src/main/java/com/wheels/app/core/navigation/Destinations.kt
@@ -1,5 +1,7 @@
 package com.wheels.app.core.navigation
 
+import android.net.Uri
+
 sealed class Destinations(val route: String) {
     data object Home : Destinations("home")
     data object Rides : Destinations("rides")
@@ -12,5 +14,8 @@ sealed class Destinations(val route: String) {
         fun createRoute(rideId: String, seats: Int): String = "booking_confirmation/$rideId/$seats"
     }
     data object GroupChat : Destinations("group_chat")
+    data object ReviewsRatings : Destinations("reviews_ratings/{driverName}") {
+        fun createRoute(driverName: String): String = "reviews_ratings/${Uri.encode(driverName)}"
+    }
     data object Profile : Destinations("profile")
 }

--- a/app/src/main/java/com/wheels/app/core/navigation/Destinations.kt
+++ b/app/src/main/java/com/wheels/app/core/navigation/Destinations.kt
@@ -14,8 +14,10 @@ sealed class Destinations(val route: String) {
         fun createRoute(rideId: String, seats: Int): String = "booking_confirmation/$rideId/$seats"
     }
     data object GroupChat : Destinations("group_chat")
-    data object ReviewsRatings : Destinations("reviews_ratings/{driverName}") {
-        fun createRoute(driverName: String): String = "reviews_ratings/${Uri.encode(driverName)}"
+    data object ReviewsRatings : Destinations("reviews_ratings/{origin}/{driverName}") {
+        fun createRoute(driverName: String, origin: String): String {
+            return "reviews_ratings/${Uri.encode(origin)}/${Uri.encode(driverName)}"
+        }
     }
     data object Profile : Destinations("profile")
 }

--- a/app/src/main/java/com/wheels/app/core/navigation/WheelsNavGraph.kt
+++ b/app/src/main/java/com/wheels/app/core/navigation/WheelsNavGraph.kt
@@ -24,6 +24,7 @@ import com.wheels.app.features.profile.presentation.ui.ProfileScreen
 import com.wheels.app.features.profile.presentation.viewmodel.ProfileViewModel
 import com.wheels.app.features.rides.presentation.ui.BookingConfirmationScreen
 import com.wheels.app.features.rides.presentation.ui.RideRequestScreen
+import com.wheels.app.features.rides.presentation.ui.ReviewsRatingsScreen
 import com.wheels.app.features.rides.presentation.ui.RidesScreen
 import com.wheels.app.features.rides.presentation.viewmodel.RideRequestViewModel
 import com.wheels.app.features.rides.presentation.viewmodel.RidesViewModel
@@ -123,6 +124,16 @@ fun WheelsNavGraph() {
             composable(Destinations.Profile.route) {
                 val viewModel: ProfileViewModel = hiltViewModel()
                 ProfileScreen(innerPadding = innerPadding, viewModel = viewModel)
+            }
+            composable(
+                route = Destinations.ReviewsRatings.route,
+                arguments = listOf(navArgument("driverName") { type = NavType.StringType })
+            ) { backStackEntry ->
+                ReviewsRatingsScreen(
+                    innerPadding = innerPadding,
+                    navController = navController,
+                    driverName = backStackEntry.arguments?.getString("driverName").orEmpty()
+                )
             }
         }
     }

--- a/app/src/main/java/com/wheels/app/core/navigation/WheelsNavGraph.kt
+++ b/app/src/main/java/com/wheels/app/core/navigation/WheelsNavGraph.kt
@@ -35,10 +35,14 @@ fun WheelsNavGraph() {
     val navController = rememberNavController()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentDestination = navBackStackEntry?.destination
-    val selectedRoute = currentDestination
-        ?.hierarchy
-        ?.mapNotNull { it.route }
-        ?.firstOrNull { route -> wheelsBottomNavItems.any { it.route == route } }
+    val selectedRoute = if (currentDestination?.route == Destinations.ReviewsRatings.route) {
+        navBackStackEntry?.arguments?.getString("origin")
+    } else {
+        currentDestination
+            ?.hierarchy
+            ?.mapNotNull { it.route }
+            ?.firstOrNull { route -> wheelsBottomNavItems.any { it.route == route } }
+    }
     val routesWithoutBottomBar = setOf(
         Destinations.QuickPayment.route,
         Destinations.GroupChat.route,
@@ -127,7 +131,10 @@ fun WheelsNavGraph() {
             }
             composable(
                 route = Destinations.ReviewsRatings.route,
-                arguments = listOf(navArgument("driverName") { type = NavType.StringType })
+                arguments = listOf(
+                    navArgument("origin") { type = NavType.StringType },
+                    navArgument("driverName") { type = NavType.StringType }
+                )
             ) { backStackEntry ->
                 ReviewsRatingsScreen(
                     innerPadding = innerPadding,

--- a/app/src/main/java/com/wheels/app/features/home/presentation/ui/HomeScreen.kt
+++ b/app/src/main/java/com/wheels/app/features/home/presentation/ui/HomeScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -95,7 +96,12 @@ fun HomeScreen(
             item {
                 CurrentRideSection(
                     activeRide = state.activeRide,
-                    onOpenChat = { navController.navigate(Destinations.GroupChat.route) }
+                    onOpenChat = { navController.navigate(Destinations.GroupChat.route) },
+                    onOpenReviews = {
+                        navController.navigate(
+                            Destinations.ReviewsRatings.createRoute(state.activeRide.driver)
+                        )
+                    }
                 )
             }
             item {
@@ -379,7 +385,8 @@ private fun DriverMarker(modifier: Modifier = Modifier) {
 @Composable
 private fun CurrentRideSection(
     activeRide: ActiveRideUiModel,
-    onOpenChat: () -> Unit
+    onOpenChat: () -> Unit,
+    onOpenReviews: () -> Unit
 ) {
     Card(
         modifier = Modifier
@@ -420,7 +427,8 @@ private fun CurrentRideSection(
                     modifier = Modifier
                         .size(56.dp)
                         .clip(CircleShape)
-                        .background(Brush.linearGradient(listOf(Color(0xFF5B89C8), PrimaryBlue))),
+                        .background(Brush.linearGradient(listOf(Color(0xFF5B89C8), PrimaryBlue)))
+                        .clickable(onClick = onOpenReviews),
                     contentAlignment = Alignment.Center
                 ) {
                     Text(
@@ -436,9 +444,13 @@ private fun CurrentRideSection(
                     Text(
                         text = activeRide.driver,
                         style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
-                        color = PrimaryBlue
+                        color = PrimaryBlue,
+                        modifier = Modifier.clickable(onClick = onOpenReviews)
                     )
-                    Row(verticalAlignment = Alignment.CenterVertically) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.clickable(onClick = onOpenReviews)
+                    ) {
                         Icon(
                             imageVector = Icons.Default.Star,
                             contentDescription = "Rating",

--- a/app/src/main/java/com/wheels/app/features/home/presentation/ui/HomeScreen.kt
+++ b/app/src/main/java/com/wheels/app/features/home/presentation/ui/HomeScreen.kt
@@ -99,7 +99,10 @@ fun HomeScreen(
                     onOpenChat = { navController.navigate(Destinations.GroupChat.route) },
                     onOpenReviews = {
                         navController.navigate(
-                            Destinations.ReviewsRatings.createRoute(state.activeRide.driver)
+                            Destinations.ReviewsRatings.createRoute(
+                                driverName = state.activeRide.driver,
+                                origin = Destinations.Home.route
+                            )
                         )
                     }
                 )

--- a/app/src/main/java/com/wheels/app/features/payments/presentation/ui/QuickPaymentScreen.kt
+++ b/app/src/main/java/com/wheels/app/features/payments/presentation/ui/QuickPaymentScreen.kt
@@ -22,13 +22,13 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.CreditCard
-import androidx.compose.material.icons.filled.ChevronLeft
-import androidx.compose.material.icons.filled.ChevronRight
-import androidx.compose.material.icons.filled.QrCode2
-import androidx.compose.material.icons.filled.Shield
-import androidx.compose.material.icons.filled.Wallet
+import androidx.compose.material.icons.outlined.AccountBalanceWallet
+import androidx.compose.material.icons.outlined.Check
+import androidx.compose.material.icons.outlined.CreditCard
+import androidx.compose.material.icons.outlined.ChevronLeft
+import androidx.compose.material.icons.outlined.ChevronRight
+import androidx.compose.material.icons.outlined.QrCode2
+import androidx.compose.material.icons.outlined.Shield
 import androidx.compose.material.icons.outlined.Schedule
 import androidx.compose.material3.Icon
 import androidx.compose.material3.HorizontalDivider
@@ -92,21 +92,21 @@ fun QuickPaymentScreen(
         PaymentMethod(
             id = "card",
             name = "Credit/Debit Card",
-            icon = Icons.Default.CreditCard,
+            icon = Icons.Outlined.CreditCard,
             saved = true,
             details = "•••• 4532"
         ),
         PaymentMethod(
             id = "wallet",
             name = "Digital Wallet",
-            icon = Icons.Default.Wallet,
+            icon = Icons.Outlined.AccountBalanceWallet,
             saved = true,
             details = "Balance: $${formatCopAmount("15000")}"
         ),
         PaymentMethod(
             id = "qr",
             name = "QR Code Payment",
-            icon = Icons.Default.QrCode2,
+            icon = Icons.Outlined.QrCode2,
             saved = false,
             details = "Scan QR to pay"
         )
@@ -186,7 +186,7 @@ private fun HeaderSection(navController: NavController) {
                 horizontalArrangement = Arrangement.spacedBy(4.dp)
             ) {
                 Icon(
-                    imageVector = Icons.Default.ChevronLeft,
+                    imageVector = Icons.Outlined.ChevronLeft,
                     contentDescription = "Back",
                     tint = WheelsSurface,
                     modifier = Modifier
@@ -255,7 +255,7 @@ private fun AmountCard(fare: String, modifier: Modifier = Modifier) {
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Icon(
-                    imageVector = Icons.Default.Check,
+                    imageVector = Icons.Outlined.Check,
                     contentDescription = null,
                     tint = ElectricGreen,
                     modifier = Modifier
@@ -480,7 +480,7 @@ private fun PaymentMethodCard(
             ) {
                 if (isSelected) {
                     Icon(
-                        imageVector = Icons.Default.Check,
+                        imageVector = Icons.Outlined.Check,
                         contentDescription = null,
                         tint = WheelsSurface,
                         modifier = Modifier
@@ -510,7 +510,7 @@ private fun SecurityNoticeSection(modifier: Modifier = Modifier) {
             verticalAlignment = Alignment.Top
         ) {
             Icon(
-                imageVector = Icons.Default.Shield,
+                imageVector = Icons.Outlined.Shield,
                 contentDescription = null,
                 tint = SecondaryBlue,
                 modifier = Modifier
@@ -611,7 +611,7 @@ private fun PaymentButton(
                     )
                     Spacer(modifier = Modifier.width(8.dp))
                     Icon(
-                        imageVector = Icons.Default.ChevronRight,
+                        imageVector = Icons.Outlined.ChevronRight,
                         contentDescription = null,
                         tint = WheelsSurface,
                         modifier = Modifier

--- a/app/src/main/java/com/wheels/app/features/rides/presentation/ui/ReviewsRatingsScreen.kt
+++ b/app/src/main/java/com/wheels/app/features/rides/presentation/ui/ReviewsRatingsScreen.kt
@@ -21,9 +21,9 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.AccessTime
 import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.ChevronLeft
 import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Shield
@@ -189,15 +189,17 @@ private fun ReviewsHeader(driverName: String, onBack: () -> Unit) {
                 .clip(RoundedCornerShape(999.dp))
                 .clickable(onClick = onBack)
                 .padding(vertical = 6.dp),
-            verticalAlignment = Alignment.CenterVertically
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp)
         ) {
             Icon(
-                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                imageVector = Icons.Default.ChevronLeft,
                 contentDescription = "Back",
                 tint = WheelsSurface,
-                modifier = Modifier.size(20.dp)
+                modifier = Modifier
+                    .width(20.dp)
+                    .height(20.dp)
             )
-            Spacer(modifier = Modifier.width(8.dp))
             Text(
                 text = "Back",
                 color = WheelsSurface.copy(alpha = 0.84f),

--- a/app/src/main/java/com/wheels/app/features/rides/presentation/ui/ReviewsRatingsScreen.kt
+++ b/app/src/main/java/com/wheels/app/features/rides/presentation/ui/ReviewsRatingsScreen.kt
@@ -21,15 +21,14 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.AccessTime
-import androidx.compose.material.icons.filled.CheckCircle
-import androidx.compose.material.icons.filled.ChevronLeft
-import androidx.compose.material.icons.filled.FilterList
-import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material.icons.filled.Shield
-import androidx.compose.material.icons.filled.Star
-import androidx.compose.material.icons.filled.TrendingUp
-import androidx.compose.material3.Button
+import androidx.compose.material.icons.outlined.AccessTime
+import androidx.compose.material.icons.outlined.CheckCircle
+import androidx.compose.material.icons.outlined.ChevronLeft
+import androidx.compose.material.icons.outlined.FilterList
+import androidx.compose.material.icons.outlined.KeyboardArrowDown
+import androidx.compose.material.icons.outlined.Shield
+import androidx.compose.material.icons.outlined.Star
+import androidx.compose.material.icons.outlined.TrendingUp
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
@@ -161,14 +160,25 @@ fun ReviewsRatingsScreen(
         }
 
         item {
-            Button(
-                onClick = {},
+            Surface(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
-                shape = RoundedCornerShape(16.dp)
+                    .padding(horizontal = 16.dp, vertical = 8.dp)
+                    .clickable { },
+                shape = RoundedCornerShape(16.dp),
+                color = WheelsSurface,
+                border = androidx.compose.foundation.BorderStroke(2.dp, Color(0xFFE5E9F2))
             ) {
-                Text(text = "Load more reviews")
+                Box(
+                    modifier = Modifier.padding(vertical = 12.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = "Load more reviews",
+                        color = PrimaryBlue,
+                        style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium)
+                    )
+                }
             }
         }
     }
@@ -193,7 +203,7 @@ private fun ReviewsHeader(driverName: String, onBack: () -> Unit) {
             horizontalArrangement = Arrangement.spacedBy(4.dp)
         ) {
             Icon(
-                imageVector = Icons.Default.ChevronLeft,
+                imageVector = Icons.Outlined.ChevronLeft,
                 contentDescription = "Back",
                 tint = WheelsSurface,
                 modifier = Modifier
@@ -248,7 +258,7 @@ private fun RatingSummaryCard(driverName: String) {
                     Row(horizontalArrangement = Arrangement.spacedBy(2.dp)) {
                         repeat(5) {
                             Icon(
-                                imageVector = Icons.Default.Star,
+                                imageVector = Icons.Outlined.Star,
                                 contentDescription = null,
                                 tint = Color(0xFFFFA726),
                                 modifier = Modifier.size(18.dp)
@@ -315,7 +325,7 @@ private fun RatingSummaryCard(driverName: String) {
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Icon(
-                        imageVector = Icons.Default.Shield,
+                        imageVector = Icons.Outlined.Shield,
                         contentDescription = null,
                         tint = ElectricGreen,
                         modifier = Modifier.size(22.dp)
@@ -334,7 +344,7 @@ private fun RatingSummaryCard(driverName: String) {
                         )
                     }
                     Icon(
-                        imageVector = Icons.Default.CheckCircle,
+                        imageVector = Icons.Outlined.CheckCircle,
                         contentDescription = null,
                         tint = ElectricGreen,
                         modifier = Modifier.size(18.dp)
@@ -346,13 +356,13 @@ private fun RatingSummaryCard(driverName: String) {
 
             Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
                 MetricBox(
-                    icon = Icons.Default.AccessTime,
+                    icon = Icons.Outlined.AccessTime,
                     label = "Punctuality",
                     value = "${driverStats.punctualityScore}%",
                     modifier = Modifier.weight(1f)
                 )
                 MetricBox(
-                    icon = Icons.Default.CheckCircle,
+                    icon = Icons.Outlined.CheckCircle,
                     label = "Payment",
                     value = "${driverStats.paymentReliability}%",
                     modifier = Modifier.weight(1f)
@@ -388,7 +398,7 @@ private fun MetricBox(
                     color = PrimaryBlue
                 )
                 Spacer(modifier = Modifier.width(4.dp))
-                Icon(imageVector = Icons.Default.TrendingUp, contentDescription = null, tint = ElectricGreen, modifier = Modifier.size(14.dp))
+                Icon(imageVector = Icons.Outlined.TrendingUp, contentDescription = null, tint = ElectricGreen, modifier = Modifier.size(14.dp))
             }
         }
     }
@@ -412,11 +422,11 @@ private fun FiltersRow() {
                 modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Icon(imageVector = Icons.Default.FilterList, contentDescription = null, tint = PrimaryBlue, modifier = Modifier.size(16.dp))
+                Icon(imageVector = Icons.Outlined.FilterList, contentDescription = null, tint = PrimaryBlue, modifier = Modifier.size(16.dp))
                 Spacer(modifier = Modifier.width(6.dp))
                 Text(text = "All reviews", color = PrimaryBlue, style = MaterialTheme.typography.bodyMedium)
                 Spacer(modifier = Modifier.width(6.dp))
-                Icon(imageVector = Icons.Default.KeyboardArrowDown, contentDescription = null, tint = PrimaryBlue, modifier = Modifier.size(16.dp))
+                Icon(imageVector = Icons.Outlined.KeyboardArrowDown, contentDescription = null, tint = PrimaryBlue, modifier = Modifier.size(16.dp))
             }
         }
 
@@ -432,7 +442,7 @@ private fun FiltersRow() {
             ) {
                 Text(text = "Most recent", color = PrimaryBlue, style = MaterialTheme.typography.bodyMedium)
                 Spacer(modifier = Modifier.width(6.dp))
-                Icon(imageVector = Icons.Default.KeyboardArrowDown, contentDescription = null, tint = PrimaryBlue, modifier = Modifier.size(16.dp))
+                Icon(imageVector = Icons.Outlined.KeyboardArrowDown, contentDescription = null, tint = PrimaryBlue, modifier = Modifier.size(16.dp))
             }
         }
     }
@@ -477,7 +487,7 @@ private fun ReviewCard(review: ReviewItem) {
                         if (review.verified) {
                             Spacer(modifier = Modifier.width(6.dp))
                             Icon(
-                                imageVector = Icons.Default.CheckCircle,
+                                imageVector = Icons.Outlined.CheckCircle,
                                 contentDescription = null,
                                 tint = ElectricGreen,
                                 modifier = Modifier.size(14.dp)
@@ -495,7 +505,7 @@ private fun ReviewCard(review: ReviewItem) {
                 Row(horizontalArrangement = Arrangement.spacedBy(2.dp)) {
                     repeat(review.rating) {
                         Icon(
-                            imageVector = Icons.Default.Star,
+                            imageVector = Icons.Outlined.Star,
                             contentDescription = null,
                             tint = Color(0xFFFFA726),
                             modifier = Modifier.size(14.dp)
@@ -536,7 +546,7 @@ private fun ReviewCard(review: ReviewItem) {
                 Spacer(modifier = Modifier.height(10.dp))
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Icon(
-                        imageVector = Icons.Default.CheckCircle,
+                        imageVector = Icons.Outlined.CheckCircle,
                         contentDescription = null,
                         tint = ElectricGreen,
                         modifier = Modifier.size(14.dp)

--- a/app/src/main/java/com/wheels/app/features/rides/presentation/ui/ReviewsRatingsScreen.kt
+++ b/app/src/main/java/com/wheels/app/features/rides/presentation/ui/ReviewsRatingsScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -33,7 +34,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -218,6 +218,7 @@ private fun ReviewsHeader(driverName: String, onBack: () -> Unit) {
             style = MaterialTheme.typography.bodyMedium,
             color = WheelsSurface.copy(alpha = 0.82f)
         )
+        Spacer(modifier = Modifier.height(18.dp))
     }
 }
 
@@ -226,7 +227,8 @@ private fun RatingSummaryCard(driverName: String) {
     Card(
         modifier = Modifier
             .padding(horizontal = 16.dp)
-            .padding(top = 10.dp)
+            .padding(top = 8.dp)
+            .offset(y = (-25).dp)
             .fillMaxWidth(),
         shape = RoundedCornerShape(24.dp),
         colors = CardDefaults.cardColors(containerColor = WheelsSurface),
@@ -273,15 +275,20 @@ private fun RatingSummaryCard(driverName: String) {
                                 modifier = Modifier.width(12.dp)
                             )
                             Spacer(modifier = Modifier.width(4.dp))
-                            LinearProgressIndicator(
-                                progress = { progress },
+                            Box(
                                 modifier = Modifier
                                     .weight(1f)
                                     .height(6.dp)
-                                    .clip(RoundedCornerShape(999.dp)),
-                                color = Color(0xFFFFA726),
-                                trackColor = Color(0xFFE8F0F9)
-                            )
+                                    .clip(RoundedCornerShape(999.dp))
+                                    .background(Color(0xFFE8F0F9))
+                            ) {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth(progress.coerceIn(0f, 1f))
+                                        .height(6.dp)
+                                        .background(Color(0xFFFFA726))
+                                )
+                            }
                             Spacer(modifier = Modifier.width(8.dp))
                             Text(
                                 text = "$votes",

--- a/app/src/main/java/com/wheels/app/features/rides/presentation/ui/ReviewsRatingsScreen.kt
+++ b/app/src/main/java/com/wheels/app/features/rides/presentation/ui/ReviewsRatingsScreen.kt
@@ -1,0 +1,545 @@
+package com.wheels.app.features.rides.presentation.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.AccessTime
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.FilterList
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.Shield
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.TrendingUp
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.wheels.app.core.ui.theme.Border
+import com.wheels.app.core.ui.theme.ElectricGreen
+import com.wheels.app.core.ui.theme.PrimaryBlue
+import com.wheels.app.core.ui.theme.SecondaryBlue
+import com.wheels.app.core.ui.theme.TextSecondary
+import com.wheels.app.core.ui.theme.WheelsBackground
+import com.wheels.app.core.ui.theme.WheelsSurface
+
+private data class ReviewItem(
+    val id: Int,
+    val reviewer: String,
+    val role: String,
+    val rating: Int,
+    val date: String,
+    val comment: String,
+    val tags: List<String>,
+    val verified: Boolean,
+    val paymentOnTime: Boolean
+)
+
+private data class DriverStats(
+    val overallRating: Double,
+    val totalReviews: Int,
+    val ratingBreakdown: Map<Int, Int>,
+    val punctualityScore: Int,
+    val paymentReliability: Int,
+    val verifiedStudent: Boolean
+)
+
+private val mockReviews = listOf(
+    ReviewItem(
+        id = 1,
+        reviewer = "Maria Gonzalez",
+        role = "Passenger",
+        rating = 5,
+        date = "2 days ago",
+        comment = "Amazing driver! Very punctual and professional. The ride was smooth and comfortable.",
+        tags = listOf("Punctual", "Safe driving", "Friendly"),
+        verified = true,
+        paymentOnTime = true
+    ),
+    ReviewItem(
+        id = 2,
+        reviewer = "Carlos Ruiz",
+        role = "Passenger",
+        rating = 5,
+        date = "5 days ago",
+        comment = "Great experience! Easy payment and good conversation. Will definitely ride again.",
+        tags = listOf("Good communication", "Clean car"),
+        verified = true,
+        paymentOnTime = true
+    ),
+    ReviewItem(
+        id = 3,
+        reviewer = "Ana Martinez",
+        role = "Driver",
+        rating = 5,
+        date = "1 week ago",
+        comment = "Perfect passenger! On time, respectful, and paid immediately after the ride.",
+        tags = listOf("Punctual", "Respectful", "Quick payment"),
+        verified = true,
+        paymentOnTime = true
+    ),
+    ReviewItem(
+        id = 4,
+        reviewer = "Juan Lopez",
+        role = "Passenger",
+        rating = 4,
+        date = "1 week ago",
+        comment = "Good ride overall. Minor delay but good communication throughout.",
+        tags = listOf("Good communication"),
+        verified = true,
+        paymentOnTime = true
+    )
+)
+
+private val driverStats = DriverStats(
+    overallRating = 4.9,
+    totalReviews = 124,
+    ratingBreakdown = mapOf(5 to 98, 4 to 20, 3 to 4, 2 to 1, 1 to 1),
+    punctualityScore = 96,
+    paymentReliability = 99,
+    verifiedStudent = true
+)
+
+@Composable
+fun ReviewsRatingsScreen(
+    innerPadding: PaddingValues,
+    navController: NavController,
+    driverName: String
+) {
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(WheelsBackground)
+            .padding(innerPadding),
+        contentPadding = PaddingValues(bottom = 24.dp)
+    ) {
+        item {
+            ReviewsHeader(driverName = driverName, onBack = { navController.popBackStack() })
+        }
+
+        item {
+            RatingSummaryCard(driverName = driverName)
+        }
+
+        item {
+            FiltersRow()
+        }
+
+        items(mockReviews, key = { it.id }) { review ->
+            ReviewCard(review = review)
+        }
+
+        item {
+            Button(
+                onClick = {},
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                shape = RoundedCornerShape(16.dp)
+            ) {
+                Text(text = "Load more reviews")
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReviewsHeader(driverName: String, onBack: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(bottomStart = 24.dp, bottomEnd = 24.dp))
+            .background(Brush.linearGradient(listOf(PrimaryBlue, Color(0xFF2D5280))))
+            .padding(horizontal = 20.dp, vertical = 18.dp)
+            .padding(top = 20.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .clip(RoundedCornerShape(999.dp))
+                .clickable(onClick = onBack)
+                .padding(vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = "Back",
+                tint = WheelsSurface,
+                modifier = Modifier.size(20.dp)
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = "Back",
+                color = WheelsSurface.copy(alpha = 0.84f),
+                style = MaterialTheme.typography.bodyMedium
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = "Reviews and Ratings",
+            style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
+            color = WheelsSurface
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = "$driverName profile",
+            style = MaterialTheme.typography.bodyMedium,
+            color = WheelsSurface.copy(alpha = 0.82f)
+        )
+    }
+}
+
+@Composable
+private fun RatingSummaryCard(driverName: String) {
+    Card(
+        modifier = Modifier
+            .padding(horizontal = 16.dp)
+            .padding(top = 10.dp)
+            .fillMaxWidth(),
+        shape = RoundedCornerShape(24.dp),
+        colors = CardDefaults.cardColors(containerColor = WheelsSurface),
+        elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
+    ) {
+        Column(modifier = Modifier.padding(20.dp)) {
+            Row {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(
+                        text = "${driverStats.overallRating}",
+                        style = MaterialTheme.typography.displaySmall.copy(fontWeight = FontWeight.Bold),
+                        color = PrimaryBlue
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Row(horizontalArrangement = Arrangement.spacedBy(2.dp)) {
+                        repeat(5) {
+                            Icon(
+                                imageVector = Icons.Default.Star,
+                                contentDescription = null,
+                                tint = Color(0xFFFFA726),
+                                modifier = Modifier.size(18.dp)
+                            )
+                        }
+                    }
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = "${driverStats.totalReviews} reviews",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = TextSecondary
+                    )
+                }
+
+                Spacer(modifier = Modifier.width(18.dp))
+
+                Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    listOf(5, 4, 3, 2, 1).forEach { stars ->
+                        val votes = driverStats.ratingBreakdown[stars] ?: 0
+                        val progress = votes.toFloat() / driverStats.totalReviews.toFloat()
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text(
+                                text = "$stars",
+                                color = TextSecondary,
+                                style = MaterialTheme.typography.bodySmall,
+                                modifier = Modifier.width(12.dp)
+                            )
+                            Spacer(modifier = Modifier.width(4.dp))
+                            LinearProgressIndicator(
+                                progress = { progress },
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .height(6.dp)
+                                    .clip(RoundedCornerShape(999.dp)),
+                                color = Color(0xFFFFA726),
+                                trackColor = Color(0xFFE8F0F9)
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(
+                                text = "$votes",
+                                color = TextSecondary,
+                                style = MaterialTheme.typography.bodySmall,
+                                modifier = Modifier.width(20.dp)
+                            )
+                        }
+                    }
+                }
+            }
+
+            if (driverStats.verifiedStudent) {
+                Spacer(modifier = Modifier.height(16.dp))
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(16.dp))
+                        .background(ElectricGreen.copy(alpha = 0.10f))
+                        .border(1.dp, ElectricGreen.copy(alpha = 0.22f), RoundedCornerShape(16.dp))
+                        .padding(14.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Shield,
+                        contentDescription = null,
+                        tint = ElectricGreen,
+                        modifier = Modifier.size(22.dp)
+                    )
+                    Spacer(modifier = Modifier.width(10.dp))
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = "Verified Student",
+                            style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
+                            color = PrimaryBlue
+                        )
+                        Text(
+                            text = "University email verified",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = TextSecondary
+                        )
+                    }
+                    Icon(
+                        imageVector = Icons.Default.CheckCircle,
+                        contentDescription = null,
+                        tint = ElectricGreen,
+                        modifier = Modifier.size(18.dp)
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(14.dp))
+
+            Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                MetricBox(
+                    icon = Icons.Default.AccessTime,
+                    label = "Punctuality",
+                    value = "${driverStats.punctualityScore}%",
+                    modifier = Modifier.weight(1f)
+                )
+                MetricBox(
+                    icon = Icons.Default.CheckCircle,
+                    label = "Payment",
+                    value = "${driverStats.paymentReliability}%",
+                    modifier = Modifier.weight(1f)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MetricBox(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        modifier = modifier,
+        color = WheelsBackground,
+        shape = RoundedCornerShape(16.dp)
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(imageVector = icon, contentDescription = null, tint = SecondaryBlue, modifier = Modifier.size(14.dp))
+                Spacer(modifier = Modifier.width(6.dp))
+                Text(text = label, color = TextSecondary, style = MaterialTheme.typography.bodySmall)
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = value,
+                    style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
+                    color = PrimaryBlue
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Icon(imageVector = Icons.Default.TrendingUp, contentDescription = null, tint = ElectricGreen, modifier = Modifier.size(14.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun FiltersRow() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Surface(
+            modifier = Modifier.clickable { },
+            shape = RoundedCornerShape(12.dp),
+            color = WheelsSurface,
+            border = androidx.compose.foundation.BorderStroke(2.dp, Border)
+        ) {
+            Row(
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(imageVector = Icons.Default.FilterList, contentDescription = null, tint = PrimaryBlue, modifier = Modifier.size(16.dp))
+                Spacer(modifier = Modifier.width(6.dp))
+                Text(text = "All reviews", color = PrimaryBlue, style = MaterialTheme.typography.bodyMedium)
+                Spacer(modifier = Modifier.width(6.dp))
+                Icon(imageVector = Icons.Default.KeyboardArrowDown, contentDescription = null, tint = PrimaryBlue, modifier = Modifier.size(16.dp))
+            }
+        }
+
+        Surface(
+            modifier = Modifier.clickable { },
+            shape = RoundedCornerShape(12.dp),
+            color = WheelsSurface,
+            border = androidx.compose.foundation.BorderStroke(2.dp, Border)
+        ) {
+            Row(
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(text = "Most recent", color = PrimaryBlue, style = MaterialTheme.typography.bodyMedium)
+                Spacer(modifier = Modifier.width(6.dp))
+                Icon(imageVector = Icons.Default.KeyboardArrowDown, contentDescription = null, tint = PrimaryBlue, modifier = Modifier.size(16.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReviewCard(review: ReviewItem) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 6.dp),
+        shape = RoundedCornerShape(20.dp),
+        colors = CardDefaults.cardColors(containerColor = WheelsSurface),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.Top) {
+                Box(
+                    modifier = Modifier
+                        .size(44.dp)
+                        .clip(CircleShape)
+                        .background(Brush.linearGradient(listOf(Color(0xFF5B89C8), PrimaryBlue))),
+                    contentAlignment = Alignment.Center
+                ) {
+                    val initials = review.reviewer.split(" ").take(2).mapNotNull { it.firstOrNull()?.toString() }.joinToString("")
+                    Text(
+                        text = initials,
+                        color = WheelsSurface,
+                        style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold)
+                    )
+                }
+
+                Spacer(modifier = Modifier.width(10.dp))
+
+                Column(modifier = Modifier.weight(1f)) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            text = review.reviewer,
+                            style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
+                            color = PrimaryBlue
+                        )
+                        if (review.verified) {
+                            Spacer(modifier = Modifier.width(6.dp))
+                            Icon(
+                                imageVector = Icons.Default.CheckCircle,
+                                contentDescription = null,
+                                tint = ElectricGreen,
+                                modifier = Modifier.size(14.dp)
+                            )
+                        }
+                    }
+                    Spacer(modifier = Modifier.height(2.dp))
+                    Text(
+                        text = "${review.role} - ${review.date}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = TextSecondary
+                    )
+                }
+
+                Row(horizontalArrangement = Arrangement.spacedBy(2.dp)) {
+                    repeat(review.rating) {
+                        Icon(
+                            imageVector = Icons.Default.Star,
+                            contentDescription = null,
+                            tint = Color(0xFFFFA726),
+                            modifier = Modifier.size(14.dp)
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(10.dp))
+
+            Text(
+                text = review.comment,
+                style = MaterialTheme.typography.bodyMedium,
+                color = PrimaryBlue
+            )
+
+            Spacer(modifier = Modifier.height(10.dp))
+
+            Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                review.tags.forEach { tag ->
+                    Surface(
+                        shape = RoundedCornerShape(999.dp),
+                        color = Color(0xFFE8F0F9)
+                    ) {
+                        Text(
+                            text = tag,
+                            color = SecondaryBlue,
+                            style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Medium),
+                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp)
+                        )
+                    }
+                }
+            }
+
+            if (review.paymentOnTime) {
+                Spacer(modifier = Modifier.height(10.dp))
+                HorizontalDivider(color = Border)
+                Spacer(modifier = Modifier.height(10.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Default.CheckCircle,
+                        contentDescription = null,
+                        tint = ElectricGreen,
+                        modifier = Modifier.size(14.dp)
+                    )
+                    Spacer(modifier = Modifier.width(6.dp))
+                    Text(
+                        text = "On-time payment verified",
+                        style = MaterialTheme.typography.bodySmall.copy(fontWeight = FontWeight.Medium),
+                        color = ElectricGreen
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/wheels/app/features/rides/presentation/ui/RideRequestScreen.kt
+++ b/app/src/main/java/com/wheels/app/features/rides/presentation/ui/RideRequestScreen.kt
@@ -128,7 +128,16 @@ fun RideRequestScreen(
             }
             item { MapPreviewCard(ride = ride) }
             item { RouteDetailsCard(ride = ride) }
-            item { DriverInfoCard(ride = ride) }
+            item {
+                DriverInfoCard(
+                    ride = ride,
+                    onOpenReviews = {
+                        navController.navigate(
+                            Destinations.ReviewsRatings.createRoute(ride.driver.name)
+                        )
+                    }
+                )
+            }
             item {
                 SeatSelectionCard(
                     ride = ride,
@@ -342,14 +351,22 @@ private fun RouteDetailsCard(ride: RideRequestUiModel) {
 }
 
 @Composable
-private fun DriverInfoCard(ride: RideRequestUiModel) {
-    InfoCard(title = "Your Driver", trailingLabel = "View reviews") {
+private fun DriverInfoCard(
+    ride: RideRequestUiModel,
+    onOpenReviews: () -> Unit
+) {
+    InfoCard(
+        title = "Your Driver",
+        trailingLabel = "View reviews",
+        onTrailingClick = onOpenReviews
+    ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Box(
                 modifier = Modifier
                     .size(64.dp)
                     .clip(CircleShape)
-                    .background(Brush.linearGradient(listOf(Color(0xFF5B89C8), PrimaryBlue))),
+                    .background(Brush.linearGradient(listOf(Color(0xFF5B89C8), PrimaryBlue)))
+                    .clickable(onClick = onOpenReviews),
                 contentAlignment = Alignment.Center
             ) {
                 Text(
@@ -363,10 +380,14 @@ private fun DriverInfoCard(ride: RideRequestUiModel) {
                 Text(
                     text = ride.driver.name,
                     style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
-                    color = PrimaryBlue
+                    color = PrimaryBlue,
+                    modifier = Modifier.clickable(onClick = onOpenReviews)
                 )
                 Spacer(modifier = Modifier.height(4.dp))
-                Row(verticalAlignment = Alignment.CenterVertically) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.clickable(onClick = onOpenReviews)
+                ) {
                     Icon(
                         imageVector = Icons.Default.Star,
                         contentDescription = null,
@@ -426,6 +447,7 @@ private fun DriverInfoCard(ride: RideRequestUiModel) {
                 primary = "${ride.driver.reliabilityScore}%",
                 secondary = "Reliable",
                 tint = ElectricGreen,
+                onClick = onOpenReviews,
                 modifier = Modifier.weight(1f)
             )
             TrustMetric(
@@ -775,6 +797,7 @@ private fun ConfirmationDialog(
 private fun InfoCard(
     title: String,
     trailingLabel: String? = null,
+    onTrailingClick: (() -> Unit)? = null,
     content: @Composable ColumnScope.() -> Unit
 ) {
     Card(
@@ -800,7 +823,12 @@ private fun InfoCard(
                     Text(
                         text = trailingLabel,
                         color = SecondaryBlue,
-                        style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium)
+                        style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
+                        modifier = if (onTrailingClick != null) {
+                            Modifier.clickable(onClick = onTrailingClick)
+                        } else {
+                            Modifier
+                        }
                     )
                 }
             }
@@ -860,10 +888,15 @@ private fun TrustMetric(
     primary: String,
     secondary: String,
     tint: Color,
+    onClick: (() -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
     Column(
-        modifier = modifier,
+        modifier = if (onClick != null) {
+            modifier.clickable(onClick = onClick)
+        } else {
+            modifier
+        },
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Icon(imageVector = icon, contentDescription = null, tint = tint, modifier = Modifier.size(16.dp))

--- a/app/src/main/java/com/wheels/app/features/rides/presentation/ui/RideRequestScreen.kt
+++ b/app/src/main/java/com/wheels/app/features/rides/presentation/ui/RideRequestScreen.kt
@@ -133,7 +133,10 @@ fun RideRequestScreen(
                     ride = ride,
                     onOpenReviews = {
                         navController.navigate(
-                            Destinations.ReviewsRatings.createRoute(ride.driver.name)
+                            Destinations.ReviewsRatings.createRoute(
+                                driverName = ride.driver.name,
+                                origin = Destinations.Rides.route
+                            )
                         )
                     }
                 )

--- a/app/src/main/java/com/wheels/app/features/rides/presentation/ui/RidesScreen.kt
+++ b/app/src/main/java/com/wheels/app/features/rides/presentation/ui/RidesScreen.kt
@@ -132,6 +132,11 @@ fun RidesScreen(
                 onRequest = {
                     navController.navigate(Destinations.RideRequest.createRoute(ride.id))
                 },
+                onOpenReviews = {
+                    navController.navigate(
+                        Destinations.ReviewsRatings.createRoute(ride.driver)
+                    )
+                },
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp)
             )
         }
@@ -438,6 +443,7 @@ private fun SmartSuggestionCard(onClick: () -> Unit) {
 private fun RideCard(
     ride: RideCardUiModel,
     onRequest: () -> Unit,
+    onOpenReviews: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Card(
@@ -471,7 +477,8 @@ private fun RideCard(
                     modifier = Modifier
                         .size(56.dp)
                         .clip(CircleShape)
-                        .background(Brush.linearGradient(listOf(Color(0xFF5B89C8), PrimaryBlue))),
+                        .background(Brush.linearGradient(listOf(Color(0xFF5B89C8), PrimaryBlue)))
+                        .clickable(onClick = onOpenReviews),
                     contentAlignment = Alignment.Center
                 ) {
                     Text(
@@ -487,10 +494,14 @@ private fun RideCard(
                     Text(
                         text = ride.driver,
                         style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
-                        color = PrimaryBlue
+                        color = PrimaryBlue,
+                        modifier = Modifier.clickable(onClick = onOpenReviews)
                     )
                     Spacer(modifier = Modifier.height(4.dp))
-                    Row(verticalAlignment = Alignment.CenterVertically) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.clickable(onClick = onOpenReviews)
+                    ) {
                         Icon(
                             imageVector = Icons.Default.Star,
                             contentDescription = null,

--- a/app/src/main/java/com/wheels/app/features/rides/presentation/ui/RidesScreen.kt
+++ b/app/src/main/java/com/wheels/app/features/rides/presentation/ui/RidesScreen.kt
@@ -134,7 +134,10 @@ fun RidesScreen(
                 },
                 onOpenReviews = {
                     navController.navigate(
-                        Destinations.ReviewsRatings.createRoute(ride.driver)
+                        Destinations.ReviewsRatings.createRoute(
+                            driverName = ride.driver,
+                            origin = Destinations.Rides.route
+                        )
                     )
                 },
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp)


### PR DESCRIPTION
This pull request introduces a new "Reviews & Ratings" navigation destination and integrates it throughout the app, allowing users to view driver reviews from multiple screens. Additionally, it improves UI interactivity by making driver-related elements clickable to access reviews, and updates icon usage in the payments screen for consistency with outlined Material icons.

**Navigation and Reviews Feature Integration:**

* Added a new `ReviewsRatings` destination to the `Destinations` sealed class, including a route with parameters and a helper function to generate encoded routes. [[1]](diffhunk://#diff-43b92b6da219115640eac7ac5a21c994d34050da9433b407e093f3a89d781ac4R3-R4) [[2]](diffhunk://#diff-43b92b6da219115640eac7ac5a21c994d34050da9433b407e093f3a89d781ac4R17-R21)
* Registered the `ReviewsRatingsScreen` in the navigation graph, extracting parameters from the route and passing them to the screen. [[1]](diffhunk://#diff-06a3c6f74e8eb6248b52f19d368fbafc40a28d5b925a27faf1d0fa6b8d4a0407R27) [[2]](diffhunk://#diff-06a3c6f74e8eb6248b52f19d368fbafc40a28d5b925a27faf1d0fa6b8d4a0407R132-R144)
* Updated the logic for determining the selected route in the navigation bar to handle the new reviews screen.

**UI Interactivity and Access to Reviews:**

* Made driver avatars, names, and rating rows in `HomeScreen` and `RideRequestScreen` clickable to open the reviews screen, passing the appropriate driver and origin information. [[1]](diffhunk://#diff-6933e8143e1fe498e6d134f4e0a3f7c69dd8c452da89e8d3eaf7f9864636fca9L98-R107) [[2]](diffhunk://#diff-6933e8143e1fe498e6d134f4e0a3f7c69dd8c452da89e8d3eaf7f9864636fca9L382-R392) [[3]](diffhunk://#diff-6933e8143e1fe498e6d134f4e0a3f7c69dd8c452da89e8d3eaf7f9864636fca9L423-R434) [[4]](diffhunk://#diff-6933e8143e1fe498e6d134f4e0a3f7c69dd8c452da89e8d3eaf7f9864636fca9L439-R456) [[5]](diffhunk://#diff-dd9e4abdff4bb1271c05c3486efe977963023b5e67ed6e2ea15a17fec5f12fb0L131-R143) [[6]](diffhunk://#diff-dd9e4abdff4bb1271c05c3486efe977963023b5e67ed6e2ea15a17fec5f12fb0L345-R372) [[7]](diffhunk://#diff-dd9e4abdff4bb1271c05c3486efe977963023b5e67ed6e2ea15a17fec5f12fb0L366-R393) [[8]](diffhunk://#diff-dd9e4abdff4bb1271c05c3486efe977963023b5e67ed6e2ea15a17fec5f12fb0R453)
* Enhanced the `InfoCard` and `TrustMetric` composables to support click actions, allowing for more interactive UI components. [[1]](diffhunk://#diff-dd9e4abdff4bb1271c05c3486efe977963023b5e67ed6e2ea15a17fec5f12fb0R803) [[2]](diffhunk://#diff-dd9e4abdff4bb1271c05c3486efe977963023b5e67ed6e2ea15a17fec5f12fb0L803-R834) [[3]](diffhunk://#diff-dd9e4abdff4bb1271c05c3486efe977963023b5e67ed6e2ea15a17fec5f12fb0R894-R902)
* Enabled access to driver reviews from the rides list by passing an `onOpenReviews` callback to each ride card. [[1]](diffhunk://#diff-7a497889a67d886dc71b3873a0055ad28bec3c549692252114bd765817a9a3ecR135-R142) [[2]](diffhunk://#diff-7a497889a67d886dc71b3873a0055ad28bec3c549692252114bd765817a9a3ecR449)

**UI Consistency Improvements:**

* Updated payment method and navigation icons in `QuickPaymentScreen` to use outlined Material icons instead of filled ones for a more modern and consistent look. [[1]](diffhunk://#diff-02fc43f6ac96c94f0653f0351cc56ac61b93c830cd074b6a9b521d0f398c0980L25-R31) [[2]](diffhunk://#diff-02fc43f6ac96c94f0653f0351cc56ac61b93c830cd074b6a9b521d0f398c0980L95-R109) [[3]](diffhunk://#diff-02fc43f6ac96c94f0653f0351cc56ac61b93c830cd074b6a9b521d0f398c0980L189-R189) [[4]](diffhunk://#diff-02fc43f6ac96c94f0653f0351cc56ac61b93c830cd074b6a9b521d0f398c0980L258-R258) [[5]](diffhunk://#diff-02fc43f6ac96c94f0653f0351cc56ac61b93c830cd074b6a9b521d0f398c0980L483-R483) [[6]](diffhunk://#diff-02fc43f6ac96c94f0653f0351cc56ac61b93c830cd074b6a9b521d0f398c0980L513-R513) [[7]](diffhunk://#diff-02fc43f6ac96c94f0653f0351cc56ac61b93c830cd074b6a9b521d0f398c0980L614-R614)

Closes #18 