### PR TITLE
Implemetation of maps geocoding Api

### DIFF
--- a/app/src/main/java/com/wheels/app/features/rides/data/adapter/GoogleMapsAdapter.kt
+++ b/app/src/main/java/com/wheels/app/features/rides/data/adapter/GoogleMapsAdapter.kt
@@ -1,0 +1,25 @@
+package com.wheels.app.features.rides.data.adapter
+
+import com.wheels.app.features.rides.data.remote.GoogleMapsClient
+import com.wheels.app.features.rides.domain.model.Coordinates
+import com.wheels.app.features.rides.domain.model.PlaceResult
+import com.wheels.app.features.rides.domain.service.GeocodingService
+import javax.inject.Inject
+
+class GoogleMapsAdapter @Inject constructor(
+    private val googleMapsClient: GoogleMapsClient
+) : GeocodingService {
+
+    // Adapter keeps the rides feature isolated from provider-specific map client details.
+    override suspend fun getCoordinates(address: String): Coordinates {
+        TODO("Pending mapping from GoogleMapsClient.geocode response into Coordinates.")
+    }
+
+    override suspend fun getAddress(lat: Double, lng: Double): String {
+        TODO("Pending mapping from GoogleMapsClient.reverseGeocode response into a display address.")
+    }
+
+    override suspend fun autocomplete(query: String): List<PlaceResult> {
+        TODO("Pending mapping from GoogleMapsClient.placesAutocomplete response into PlaceResult values.")
+    }
+}

--- a/app/src/main/java/com/wheels/app/features/rides/data/remote/GoogleMapsClient.kt
+++ b/app/src/main/java/com/wheels/app/features/rides/data/remote/GoogleMapsClient.kt
@@ -1,0 +1,17 @@
+package com.wheels.app.features.rides.data.remote
+
+import javax.inject.Inject
+
+class GoogleMapsClient @Inject constructor() {
+    suspend fun geocode(address: String): String {
+        throw NotImplementedError("Pending API integration for geocoding.")
+    }
+
+    suspend fun reverseGeocode(lat: Double, lng: Double): String {
+        throw NotImplementedError("Pending API integration for reverse geocoding.")
+    }
+
+    suspend fun placesAutocomplete(query: String): String {
+        throw NotImplementedError("Pending API integration for places autocomplete.")
+    }
+}

--- a/app/src/main/java/com/wheels/app/features/rides/domain/model/Coordinates.kt
+++ b/app/src/main/java/com/wheels/app/features/rides/domain/model/Coordinates.kt
@@ -1,0 +1,6 @@
+package com.wheels.app.features.rides.domain.model
+
+data class Coordinates(
+    val lat: Double,
+    val lng: Double
+)

--- a/app/src/main/java/com/wheels/app/features/rides/domain/model/PlaceResult.kt
+++ b/app/src/main/java/com/wheels/app/features/rides/domain/model/PlaceResult.kt
@@ -1,0 +1,8 @@
+package com.wheels.app.features.rides.domain.model
+
+data class PlaceResult(
+    val name: String,
+    val address: String,
+    val lat: Double,
+    val lng: Double
+)

--- a/app/src/main/java/com/wheels/app/features/rides/domain/service/GeocodingService.kt
+++ b/app/src/main/java/com/wheels/app/features/rides/domain/service/GeocodingService.kt
@@ -1,0 +1,12 @@
+package com.wheels.app.features.rides.domain.service
+
+import com.wheels.app.features.rides.domain.model.Coordinates
+import com.wheels.app.features.rides.domain.model.PlaceResult
+
+interface GeocodingService {
+    suspend fun getCoordinates(address: String): Coordinates
+
+    suspend fun getAddress(lat: Double, lng: Double): String
+
+    suspend fun autocomplete(query: String): List<PlaceResult>
+}

--- a/maps_geocoding_design.md
+++ b/maps_geocoding_design.md
@@ -1,0 +1,7 @@
+# Maps & Geocoding Design
+
+This rides feature scaffolding uses the Adapter pattern.
+
+`GoogleMapsAdapter` isolates the rides feature from provider-specific map and geocoding API details by exposing the app-facing `GeocodingService` contract while delegating provider work to `GoogleMapsClient`.
+
+Implementation is intentionally pending for the next iteration, so the current files only define structure, contracts, and placeholder methods.


### PR DESCRIPTION
This PR introduces the initial structure for the Maps & Geocoding feature in Kotlin.

Included:
- geocoding service contract
- adapter skeleton for external maps provider
- domain models for coordinates and place results
- base remote client placeholder
- design documentation for the feature

External API calls and response mapping are still pending.