### PR TITLE
feature of time usage

### DIFF
--- a/app/src/main/java/com/wheels/app/features/auth/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/wheels/app/features/auth/data/repository/AuthRepositoryImpl.kt
@@ -11,9 +11,12 @@ import com.wheels.app.features.profile.data.remote.dto.UserDto
 import com.wheels.app.features.profile.data.remote.mapper.toDomain
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
+import java.util.Collections
 import javax.inject.Inject
 
 class AuthRepositoryImpl @Inject constructor() : AuthRepository {
+    private val loginHistoryTimestamps = Collections.synchronizedList(mutableListOf<Long>())
+
     override fun getCurrentUser(): Flow<User?> = flowOf(
         User(
             id = "u_001",
@@ -25,6 +28,8 @@ class AuthRepositoryImpl @Inject constructor() : AuthRepository {
             isDriver = true
         )
     )
+
+    override fun getLoginHistory(): List<Long> = loginHistoryTimestamps.toList()
 
     override suspend fun createAccount(request: CreateAccountRequest): Resource<User> {
         val requestDto = request.toDto()
@@ -68,6 +73,7 @@ class AuthRepositoryImpl @Inject constructor() : AuthRepository {
             ridesCompleted = 24,
             isDriver = false
         )
+        loginHistoryTimestamps.add(System.currentTimeMillis())
         return Resource.Success(signedInUser.toDomain())
     }
 

--- a/app/src/main/java/com/wheels/app/features/auth/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/wheels/app/features/auth/domain/repository/AuthRepository.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.Flow
 
 interface AuthRepository {
     fun getCurrentUser(): Flow<User?>
+    fun getLoginHistory(): List<Long>
 
     suspend fun createAccount(request: CreateAccountRequest): Resource<User>
 


### PR DESCRIPTION
This pull request adds a login history feature to the authentication repository. It tracks the timestamps of successful logins and exposes a method to retrieve this history. The main changes are grouped below:

**Login History Feature:**

* Added a thread-safe list (`loginHistoryTimestamps`) in `AuthRepositoryImpl` to store login timestamps.
* Implemented the `getLoginHistory()` method in both the `AuthRepository` interface and its implementation to allow retrieval of login timestamps. [[1]](diffhunk://#diff-81fbb8bcbd2bb29a320e1d3a35218ffcd44dd9a55222a265bf77fd466d6d85a5R12) [[2]](diffhunk://#diff-e1d8d81e49303aea2583509bde2d6b2bf9fce3e664d8c9e074b2884bb358f05eR32-R33)
* Updated the `signIn` logic in `AuthRepositoryImpl` to record the current timestamp to `loginHistoryTimestamps` on each successful login.