### PR TITLE
Feature/dark mode context aware #56

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ local.properties
 *.iml
 .vscode/
 MOCKUP-PASSENGER/
+DOCS/
 
 # Keystore and secrets
 *.jks

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,6 +70,7 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.7")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.7")
     implementation("androidx.activity:activity-compose:1.10.1")
+    implementation("androidx.datastore:datastore-preferences:1.1.1")
 
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling-preview")

--- a/app/src/main/java/com/wheels/app/MainActivity.kt
+++ b/app/src/main/java/com/wheels/app/MainActivity.kt
@@ -3,7 +3,10 @@ package com.wheels.app
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.wheels.app.core.navigation.WheelsNavGraph
+import com.wheels.app.core.theme.ThemeSettingsViewModel
 import com.wheels.app.core.ui.theme.WheelsTheme
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -12,8 +15,11 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            WheelsTheme {
-                WheelsNavGraph()
+            val themeViewModel: ThemeSettingsViewModel = hiltViewModel()
+            val themeState = themeViewModel.uiState.collectAsStateWithLifecycle()
+
+            WheelsTheme(darkTheme = themeState.value.isDarkModeEnabled) {
+                WheelsNavGraph(themeViewModel = themeViewModel)
             }
         }
     }

--- a/app/src/main/java/com/wheels/app/MainActivity.kt
+++ b/app/src/main/java/com/wheels/app/MainActivity.kt
@@ -18,7 +18,7 @@ class MainActivity : ComponentActivity() {
             val themeViewModel: ThemeSettingsViewModel = hiltViewModel()
             val themeState = themeViewModel.uiState.collectAsStateWithLifecycle()
 
-            WheelsTheme(darkTheme = themeState.value.isDarkModeEnabled) {
+            WheelsTheme(darkTheme = themeState.value.effectiveDarkTheme) {
                 WheelsNavGraph(themeViewModel = themeViewModel)
             }
         }

--- a/app/src/main/java/com/wheels/app/core/navigation/Destinations.kt
+++ b/app/src/main/java/com/wheels/app/core/navigation/Destinations.kt
@@ -28,4 +28,5 @@ sealed class Destinations(val route: String) {
     }
     data object Profile : Destinations("profile")
     data object TrustFairness : Destinations("trust_fairness")
+    data object UiTheme : Destinations("ui_theme")
 }

--- a/app/src/main/java/com/wheels/app/core/navigation/WheelsNavGraph.kt
+++ b/app/src/main/java/com/wheels/app/core/navigation/WheelsNavGraph.kt
@@ -15,6 +15,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.wheels.app.core.ui.components.WheelsBottomBar
+import com.wheels.app.core.theme.ThemeSettingsViewModel
 import com.wheels.app.features.auth.presentation.session.AuthSessionViewModel
 import com.wheels.app.features.auth.presentation.session.SessionGateScreen
 import com.wheels.app.features.auth.presentation.ui.CreateAccountScreen
@@ -44,9 +45,9 @@ import com.wheels.app.features.rides.presentation.viewmodel.RidesViewModel
 import com.wheels.app.features.rides.presentation.viewmodel.mockRideRequestData
 
 @Composable
-fun WheelsNavGraph() {
+fun WheelsNavGraph(themeViewModel: ThemeSettingsViewModel) {
     val navController = rememberNavController()
-    val sessionViewModel: AuthSessionViewModel = hiltViewModel()
+        val sessionViewModel: AuthSessionViewModel = hiltViewModel()
     val sessionState by sessionViewModel.uiState.collectAsState()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentDestination = navBackStackEntry?.destination
@@ -231,7 +232,8 @@ fun WheelsNavGraph() {
             composable(Destinations.UiTheme.route) {
                 UiThemeScreen(
                     innerPadding = innerPadding,
-                    navController = navController
+                    navController = navController,
+                    viewModel = themeViewModel
                 )
             }
             composable(

--- a/app/src/main/java/com/wheels/app/core/navigation/WheelsNavGraph.kt
+++ b/app/src/main/java/com/wheels/app/core/navigation/WheelsNavGraph.kt
@@ -32,6 +32,7 @@ import com.wheels.app.features.payments.presentation.ui.QuickPaymentScreen
 import com.wheels.app.features.payments.presentation.viewmodel.PaymentsViewModel
 import com.wheels.app.features.profile.presentation.ui.ProfileScreen
 import com.wheels.app.features.profile.presentation.ui.TrustFairnessScreen
+import com.wheels.app.features.profile.presentation.ui.UiThemeScreen
 import com.wheels.app.features.profile.presentation.viewmodel.ProfileViewModel
 import com.wheels.app.features.rides.presentation.ui.ActiveRideManagementScreen
 import com.wheels.app.features.rides.presentation.ui.BookingConfirmationScreen
@@ -225,6 +226,12 @@ fun WheelsNavGraph() {
                     innerPadding = innerPadding,
                     navController = navController,
                     viewModel = viewModel
+                )
+            }
+            composable(Destinations.UiTheme.route) {
+                UiThemeScreen(
+                    innerPadding = innerPadding,
+                    navController = navController
                 )
             }
             composable(

--- a/app/src/main/java/com/wheels/app/core/theme/AmbientLightMonitor.kt
+++ b/app/src/main/java/com/wheels/app/core/theme/AmbientLightMonitor.kt
@@ -1,0 +1,58 @@
+package com.wheels.app.core.theme
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+
+data class AmbientLightState(
+    val isLightSensorAvailable: Boolean,
+    val ambientLux: Float? = null
+)
+
+@Singleton
+class AmbientLightMonitor @Inject constructor(
+    @ApplicationContext context: Context
+) {
+    private val sensorManager = context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
+    private val lightSensor: Sensor? = sensorManager.getDefaultSensor(Sensor.TYPE_LIGHT)
+
+    val ambientLightState: Flow<AmbientLightState> = callbackFlow {
+        val sensor = lightSensor
+        if (sensor == null) {
+            trySend(AmbientLightState(isLightSensorAvailable = false))
+            close()
+            return@callbackFlow
+        }
+
+        trySend(AmbientLightState(isLightSensorAvailable = true))
+
+        val listener = object : SensorEventListener {
+            override fun onSensorChanged(event: SensorEvent) {
+                val lux = event.values.firstOrNull()
+                trySend(
+                    AmbientLightState(
+                        isLightSensorAvailable = true,
+                        ambientLux = lux
+                    )
+                )
+            }
+
+            override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) = Unit
+        }
+
+        sensorManager.registerListener(listener, sensor, SensorManager.SENSOR_DELAY_NORMAL)
+
+        awaitClose {
+            sensorManager.unregisterListener(listener)
+        }
+    }.distinctUntilChanged()
+}

--- a/app/src/main/java/com/wheels/app/core/theme/ThemePreferencesRepository.kt
+++ b/app/src/main/java/com/wheels/app/core/theme/ThemePreferencesRepository.kt
@@ -1,0 +1,35 @@
+package com.wheels.app.core.theme
+
+import android.content.Context
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStoreFile
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+@Singleton
+class ThemePreferencesRepository @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private val dataStore = PreferenceDataStoreFactory.create(
+        produceFile = { context.preferencesDataStoreFile("theme_preferences") }
+    )
+
+    val isDarkModeEnabled: Flow<Boolean> = dataStore.data.map { preferences ->
+        preferences[DARK_MODE_ENABLED] ?: false
+    }
+
+    suspend fun setDarkModeEnabled(enabled: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[DARK_MODE_ENABLED] = enabled
+        }
+    }
+
+    private companion object {
+        val DARK_MODE_ENABLED = booleanPreferencesKey("dark_mode_enabled")
+    }
+}

--- a/app/src/main/java/com/wheels/app/core/theme/ThemePreferencesRepository.kt
+++ b/app/src/main/java/com/wheels/app/core/theme/ThemePreferencesRepository.kt
@@ -10,6 +10,12 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.distinctUntilChanged
+
+data class ThemePreferences(
+    val isDarkModeEnabled: Boolean = false,
+    val isAdaptiveThemeEnabled: Boolean = false
+)
 
 @Singleton
 class ThemePreferencesRepository @Inject constructor(
@@ -19,9 +25,14 @@ class ThemePreferencesRepository @Inject constructor(
         produceFile = { context.preferencesDataStoreFile("theme_preferences") }
     )
 
-    val isDarkModeEnabled: Flow<Boolean> = dataStore.data.map { preferences ->
-        preferences[DARK_MODE_ENABLED] ?: false
-    }
+    val themePreferences: Flow<ThemePreferences> = dataStore.data
+        .map { preferences ->
+            ThemePreferences(
+                isDarkModeEnabled = preferences[DARK_MODE_ENABLED] ?: false,
+                isAdaptiveThemeEnabled = preferences[ADAPTIVE_THEME_ENABLED] ?: false
+            )
+        }
+        .distinctUntilChanged()
 
     suspend fun setDarkModeEnabled(enabled: Boolean) {
         dataStore.edit { preferences ->
@@ -29,7 +40,14 @@ class ThemePreferencesRepository @Inject constructor(
         }
     }
 
+    suspend fun setAdaptiveThemeEnabled(enabled: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[ADAPTIVE_THEME_ENABLED] = enabled
+        }
+    }
+
     private companion object {
         val DARK_MODE_ENABLED = booleanPreferencesKey("dark_mode_enabled")
+        val ADAPTIVE_THEME_ENABLED = booleanPreferencesKey("adaptive_theme_enabled")
     }
 }

--- a/app/src/main/java/com/wheels/app/core/theme/ThemeSettingsViewModel.kt
+++ b/app/src/main/java/com/wheels/app/core/theme/ThemeSettingsViewModel.kt
@@ -1,0 +1,35 @@
+package com.wheels.app.core.theme
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+data class ThemeSettingsUiState(
+    val isDarkModeEnabled: Boolean = false
+)
+
+@HiltViewModel
+class ThemeSettingsViewModel @Inject constructor(
+    private val themePreferencesRepository: ThemePreferencesRepository
+) : ViewModel() {
+
+    val uiState: StateFlow<ThemeSettingsUiState> = themePreferencesRepository.isDarkModeEnabled
+        .map { isDarkModeEnabled -> ThemeSettingsUiState(isDarkModeEnabled = isDarkModeEnabled) }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = ThemeSettingsUiState()
+        )
+
+    fun setDarkModeEnabled(enabled: Boolean) {
+        viewModelScope.launch {
+            themePreferencesRepository.setDarkModeEnabled(enabled)
+        }
+    }
+}

--- a/app/src/main/java/com/wheels/app/core/theme/ThemeSettingsViewModel.kt
+++ b/app/src/main/java/com/wheels/app/core/theme/ThemeSettingsViewModel.kt
@@ -6,21 +6,42 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 data class ThemeSettingsUiState(
-    val isDarkModeEnabled: Boolean = false
+    val isDarkModeEnabled: Boolean = false,
+    val isAdaptiveThemeEnabled: Boolean = false,
+    val effectiveDarkTheme: Boolean = false,
+    val ambientLux: Float? = null,
+    val isLightSensorAvailable: Boolean = false
 )
 
 @HiltViewModel
 class ThemeSettingsViewModel @Inject constructor(
-    private val themePreferencesRepository: ThemePreferencesRepository
+    private val themePreferencesRepository: ThemePreferencesRepository,
+    ambientLightMonitor: AmbientLightMonitor
 ) : ViewModel() {
 
-    val uiState: StateFlow<ThemeSettingsUiState> = themePreferencesRepository.isDarkModeEnabled
-        .map { isDarkModeEnabled -> ThemeSettingsUiState(isDarkModeEnabled = isDarkModeEnabled) }
+    val uiState: StateFlow<ThemeSettingsUiState> = combine(
+        themePreferencesRepository.themePreferences,
+        ambientLightMonitor.ambientLightState
+    ) { preferences, ambientLightState ->
+        val effectiveDarkTheme = when {
+            preferences.isAdaptiveThemeEnabled && ambientLightState.isLightSensorAvailable ->
+                (ambientLightState.ambientLux ?: Float.MAX_VALUE) < LOW_LIGHT_THRESHOLD_LUX
+            else -> preferences.isDarkModeEnabled
+        }
+
+        ThemeSettingsUiState(
+            isDarkModeEnabled = preferences.isDarkModeEnabled,
+            isAdaptiveThemeEnabled = preferences.isAdaptiveThemeEnabled,
+            effectiveDarkTheme = effectiveDarkTheme,
+            ambientLux = ambientLightState.ambientLux,
+            isLightSensorAvailable = ambientLightState.isLightSensorAvailable
+        )
+    }
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5_000),
@@ -31,5 +52,15 @@ class ThemeSettingsViewModel @Inject constructor(
         viewModelScope.launch {
             themePreferencesRepository.setDarkModeEnabled(enabled)
         }
+    }
+
+    fun setAdaptiveThemeEnabled(enabled: Boolean) {
+        viewModelScope.launch {
+            themePreferencesRepository.setAdaptiveThemeEnabled(enabled)
+        }
+    }
+
+    private companion object {
+        const val LOW_LIGHT_THRESHOLD_LUX = 30f
     }
 }

--- a/app/src/main/java/com/wheels/app/core/ui/components/WheelsBottomBar.kt
+++ b/app/src/main/java/com/wheels/app/core/ui/components/WheelsBottomBar.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.outlined.PersonOutline
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -29,10 +30,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.wheels.app.core.navigation.BottomNavItem
-import com.wheels.app.core.ui.theme.Border
-import com.wheels.app.core.ui.theme.PrimaryBlue
-import com.wheels.app.core.ui.theme.TextSecondary
-import com.wheels.app.core.ui.theme.WheelsSurface
 
 @Composable
 fun WheelsBottomBar(
@@ -41,15 +38,17 @@ fun WheelsBottomBar(
     onItemSelected: (BottomNavItem) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val colorScheme = MaterialTheme.colorScheme
+
     Surface(
         modifier = modifier.fillMaxWidth(),
-        color = WheelsSurface,
+        color = colorScheme.surface,
         shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp)
     ) {
         Column {
             Divider(
                 modifier = Modifier.fillMaxWidth(),
-                color = Border,
+                color = colorScheme.outline,
                 thickness = 1.dp
             )
             Row(
@@ -78,6 +77,8 @@ private fun BottomBarItem(
     selected: Boolean,
     onClick: () -> Unit
 ) {
+    val colorScheme = MaterialTheme.colorScheme
+
     Column(
         modifier = Modifier
             .clip(RoundedCornerShape(18.dp))
@@ -94,7 +95,7 @@ private fun BottomBarItem(
 
         Text(
             text = item.label,
-            color = if (selected) PrimaryBlue else TextSecondary,
+            color = if (selected) colorScheme.primary else colorScheme.onSurfaceVariant,
             fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
             fontSize = 11.sp
         )
@@ -103,10 +104,12 @@ private fun BottomBarItem(
 
 @Composable
 private fun SelectedIconBubble(item: BottomNavItem) {
+    val colorScheme = MaterialTheme.colorScheme
+
     Surface(
         modifier = Modifier.size(32.dp),
         shape = CircleShape,
-        color = PrimaryBlue
+        color = colorScheme.primary
     ) {
         Box(contentAlignment = Alignment.Center) {
             BadgedIcon(item = item, selected = true)
@@ -123,17 +126,19 @@ private fun InactiveIconBubble(item: BottomNavItem) {
 
 @Composable
 private fun ProfileBubble(selected: Boolean) {
+    val colorScheme = MaterialTheme.colorScheme
+
     Surface(
         modifier = Modifier.size(32.dp),
         shape = CircleShape,
-        color = if (selected) PrimaryBlue else Color.Transparent,
-        border = if (selected) null else BorderStroke(1.dp, Border)
+        color = if (selected) colorScheme.primary else Color.Transparent,
+        border = if (selected) null else BorderStroke(1.dp, colorScheme.outline)
     ) {
         Box(contentAlignment = Alignment.Center) {
             Icon(
                 imageVector = Icons.Outlined.PersonOutline,
                 contentDescription = "Profile",
-                tint = if (selected) Color.White else TextSecondary
+                tint = if (selected) colorScheme.onPrimary else colorScheme.onSurfaceVariant
             )
         }
     }
@@ -141,7 +146,7 @@ private fun ProfileBubble(selected: Boolean) {
 
 @Composable
 private fun BadgedIcon(item: BottomNavItem, selected: Boolean) {
-    val iconTint = if (selected) Color.White else TextSecondary
+    val iconTint = if (selected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant
 
     if ((item.badgeCount ?: 0) > 0) {
         BadgedBox(

--- a/app/src/main/java/com/wheels/app/core/ui/theme/Color.kt
+++ b/app/src/main/java/com/wheels/app/core/ui/theme/Color.kt
@@ -1,14 +1,53 @@
 package com.wheels.app.core.ui.theme
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.Color
 
-val PrimaryBlue = Color(0xFF1A3A5C)
-val SecondaryBlue = Color(0xFF2563EB)
+private const val LIGHT_PRIMARY_BLUE = 0xFF1A3A5C
+private const val DARK_PRIMARY_BLUE = 0xFFBFDBFE
+private const val LIGHT_SECONDARY_BLUE = 0xFF2563EB
+private const val DARK_SECONDARY_BLUE = 0xFF60A5FA
+private const val LIGHT_WHEELS_BACKGROUND = 0xFFF8FAFC
+private const val DARK_WHEELS_BACKGROUND = 0xFF0F172A
+private const val LIGHT_WHEELS_SURFACE = 0xFFFFFFFF
+private const val DARK_WHEELS_SURFACE = 0xFF111827
+private const val LIGHT_TEXT_PRIMARY = 0xFF0F172A
+private const val DARK_TEXT_PRIMARY = 0xFFF8FAFC
+private const val LIGHT_TEXT_SECONDARY = 0xFF64748B
+private const val DARK_TEXT_SECONDARY = 0xFFCBD5E1
+private const val LIGHT_BORDER = 0xFFE2E8F0
+private const val DARK_BORDER = 0xFF334155
+
+private var isDarkThemePaletteEnabled by mutableStateOf(false)
+
+internal fun setThemePaletteDarkMode(isDarkThemeEnabled: Boolean) {
+    isDarkThemePaletteEnabled = isDarkThemeEnabled
+}
+
+val PrimaryBlue: Color
+    get() = Color(if (isDarkThemePaletteEnabled) DARK_PRIMARY_BLUE else LIGHT_PRIMARY_BLUE)
+
+val SecondaryBlue: Color
+    get() = Color(if (isDarkThemePaletteEnabled) DARK_SECONDARY_BLUE else LIGHT_SECONDARY_BLUE)
+
 val ElectricGreen = Color(0xFF10B981)
-val WheelsBackground = Color(0xFFF8FAFC)
-val WheelsSurface = Color(0xFFFFFFFF)
-val TextPrimary = Color(0xFF0F172A)
-val TextSecondary = Color(0xFF64748B)
+
+val WheelsBackground: Color
+    get() = Color(if (isDarkThemePaletteEnabled) DARK_WHEELS_BACKGROUND else LIGHT_WHEELS_BACKGROUND)
+
+val WheelsSurface: Color
+    get() = Color(if (isDarkThemePaletteEnabled) DARK_WHEELS_SURFACE else LIGHT_WHEELS_SURFACE)
+
+val TextPrimary: Color
+    get() = Color(if (isDarkThemePaletteEnabled) DARK_TEXT_PRIMARY else LIGHT_TEXT_PRIMARY)
+
+val TextSecondary: Color
+    get() = Color(if (isDarkThemePaletteEnabled) DARK_TEXT_SECONDARY else LIGHT_TEXT_SECONDARY)
+
 val Warning = Color(0xFFF59E0B)
 val WheelsError = Color(0xFFEF4444)
-val Border = Color(0xFFE2E8F0)
+
+val Border: Color
+    get() = Color(if (isDarkThemePaletteEnabled) DARK_BORDER else LIGHT_BORDER)

--- a/app/src/main/java/com/wheels/app/core/ui/theme/GradientHeader.kt
+++ b/app/src/main/java/com/wheels/app/core/ui/theme/GradientHeader.kt
@@ -1,0 +1,17 @@
+package com.wheels.app.core.ui.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+
+private val GradientHeaderStart = Color(0xFF1A3A5C)
+private val GradientHeaderEnd = Color(0xFF2D5280)
+
+val GradientHeaderPrimaryContent = Color.White
+val GradientHeaderSecondaryContent = Color.White.copy(alpha = 0.84f)
+val GradientHeaderIconContainer = Color.White.copy(alpha = 0.12f)
+
+@Composable
+fun gradientHeaderBrush(): Brush = Brush.linearGradient(
+    colors = listOf(GradientHeaderStart, GradientHeaderEnd)
+)

--- a/app/src/main/java/com/wheels/app/core/ui/theme/Theme.kt
+++ b/app/src/main/java/com/wheels/app/core/ui/theme/Theme.kt
@@ -5,43 +5,46 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 
 private val LightColorScheme = lightColorScheme(
-    primary = PrimaryBlue,
-    onPrimary = WheelsSurface,
-    secondary = SecondaryBlue,
-    onSecondary = WheelsSurface,
+    primary = Color(0xFF1A3A5C),
+    onPrimary = Color(0xFFFFFFFF),
+    secondary = Color(0xFF2563EB),
+    onSecondary = Color(0xFFFFFFFF),
     tertiary = ElectricGreen,
-    background = WheelsBackground,
-    onBackground = TextPrimary,
-    surface = WheelsSurface,
-    onSurface = TextPrimary,
+    background = Color(0xFFF8FAFC),
+    onBackground = Color(0xFF0F172A),
+    surface = Color(0xFFFFFFFF),
+    onSurface = Color(0xFF0F172A),
     error = WheelsError,
-    outline = Border
+    outline = Color(0xFFE2E8F0),
+    surfaceVariant = Color(0xFFE8F0F9),
+    onSurfaceVariant = Color(0xFF64748B)
 )
 
 private val DarkColorScheme = darkColorScheme(
-    primary = SecondaryBlue,
-    secondary = PrimaryBlue,
+    primary = Color(0xFFBFDBFE),
+    onPrimary = Color(0xFF0F172A),
+    secondary = Color(0xFF60A5FA),
+    onSecondary = Color(0xFF0F172A),
     tertiary = ElectricGreen,
-    background = TextPrimary,
-    onBackground = WheelsSurface,
-    surface = ColorTokens.DarkSurface,
-    onSurface = WheelsSurface,
+    background = Color(0xFF0F172A),
+    onBackground = Color(0xFFF8FAFC),
+    surface = Color(0xFF111827),
+    onSurface = Color(0xFFF8FAFC),
     error = WheelsError,
-    outline = ColorTokens.DarkOutline
+    outline = Color(0xFF334155),
+    surfaceVariant = Color(0xFF1E293B),
+    onSurfaceVariant = Color(0xFFCBD5E1)
 )
-
-private object ColorTokens {
-    val DarkSurface = androidx.compose.ui.graphics.Color(0xFF111827)
-    val DarkOutline = androidx.compose.ui.graphics.Color(0xFF334155)
-}
 
 @Composable
 fun WheelsTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit
 ) {
+    setThemePaletteDarkMode(darkTheme)
     val colorScheme = if (darkTheme) DarkColorScheme else LightColorScheme
 
     MaterialTheme(

--- a/app/src/main/java/com/wheels/app/features/auth/presentation/session/SessionGateScreen.kt
+++ b/app/src/main/java/com/wheels/app/features/auth/presentation/session/SessionGateScreen.kt
@@ -14,18 +14,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.wheels.app.core.ui.theme.PrimaryBlue
-import com.wheels.app.core.ui.theme.WheelsSurface
 
 @Composable
 fun SessionGateScreen(innerPadding: PaddingValues) {
+    val colorScheme = MaterialTheme.colorScheme
+
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(Brush.verticalGradient(listOf(Color(0xFFE8F0F9), WheelsSurface)))
+            .background(Brush.verticalGradient(listOf(colorScheme.surfaceVariant, colorScheme.background)))
             .padding(innerPadding),
         contentAlignment = Alignment.Center
     ) {
@@ -33,11 +32,11 @@ fun SessionGateScreen(innerPadding: PaddingValues) {
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            CircularProgressIndicator(color = PrimaryBlue)
+            CircularProgressIndicator(color = colorScheme.primary)
             Text(
                 text = "Restoring your session...",
                 style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
-                color = PrimaryBlue
+                color = colorScheme.onBackground
             )
         }
     }

--- a/app/src/main/java/com/wheels/app/features/auth/presentation/ui/CreateAccountScreen.kt
+++ b/app/src/main/java/com/wheels/app/features/auth/presentation/ui/CreateAccountScreen.kt
@@ -66,11 +66,12 @@ fun CreateAccountScreen(
 ) {
     val state by viewModel.uiState.collectAsState()
     val errorMessage = state.errorMessage
+    val colorScheme = MaterialTheme.colorScheme
 
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(Brush.verticalGradient(listOf(Color(0xFFE8F0F9), WheelsSurface)))
+            .background(Brush.verticalGradient(listOf(colorScheme.surfaceVariant, colorScheme.background)))
             .padding(innerPadding)
             .verticalScroll(rememberScrollState())
             .padding(horizontal = 20.dp, vertical = 16.dp)
@@ -87,7 +88,7 @@ fun CreateAccountScreen(
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                 contentDescription = "Back",
-                tint = PrimaryBlue
+                tint = colorScheme.onBackground
             )
         }
 
@@ -111,13 +112,13 @@ fun CreateAccountScreen(
             Text(
                 text = "Create Account",
                 style = MaterialTheme.typography.headlineMedium.copy(fontWeight = FontWeight.Bold),
-                color = PrimaryBlue
+                color = colorScheme.onBackground
             )
             Spacer(modifier = Modifier.height(8.dp))
             Text(
                 text = "Create your Wheels profile and start moving around campus.",
                 style = MaterialTheme.typography.bodyMedium,
-                color = TextSecondary,
+                color = colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center
             )
         }
@@ -175,12 +176,12 @@ fun CreateAccountScreen(
                     Text(
                         text = "Choose your role(s)",
                         style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
-                        color = PrimaryBlue
+                        color = colorScheme.onSurface
                     )
                     Text(
                         text = "You can register as passenger, driver, or both. If you choose both, Wheels will start in passenger mode first.",
                         style = MaterialTheme.typography.bodySmall,
-                        color = TextSecondary
+                        color = colorScheme.onSurfaceVariant
                     )
                     Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                         RoleSelectionChip(
@@ -265,8 +266,8 @@ fun CreateAccountScreen(
                         .height(56.dp),
                     shape = RoundedCornerShape(18.dp),
                     colors = ButtonDefaults.buttonColors(
-                        containerColor = PrimaryBlue,
-                        contentColor = WheelsSurface,
+                        containerColor = colorScheme.primary,
+                        contentColor = colorScheme.onPrimary,
                         disabledContainerColor = Border,
                         disabledContentColor = TextSecondary
                     )
@@ -275,7 +276,7 @@ fun CreateAccountScreen(
                         CircularProgressIndicator(
                             modifier = Modifier.size(20.dp),
                             strokeWidth = 2.dp,
-                            color = WheelsSurface
+                            color = colorScheme.onPrimary
                         )
                     } else {
                         Text(
@@ -290,7 +291,7 @@ fun CreateAccountScreen(
                 Text(
                     text = "By continuing, you accept the campus mobility rules and the Wheels community guidelines.",
                     style = MaterialTheme.typography.bodySmall,
-                    color = TextSecondary,
+                    color = colorScheme.onSurfaceVariant,
                     textAlign = TextAlign.Center,
                     modifier = Modifier.fillMaxWidth()
                 )
@@ -302,7 +303,7 @@ fun CreateAccountScreen(
         Text(
             text = "Already have an account? Sign In",
             style = MaterialTheme.typography.bodyMedium,
-            color = TextSecondary,
+            color = colorScheme.onSurfaceVariant,
             modifier = Modifier
                 .align(Alignment.CenterHorizontally)
                 .clickable {
@@ -322,17 +323,19 @@ private fun RoleSelectionChip(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val colorScheme = MaterialTheme.colorScheme
+
     OutlinedButton(
         onClick = onClick,
         modifier = modifier,
         shape = RoundedCornerShape(16.dp),
         colors = ButtonDefaults.outlinedButtonColors(
-            containerColor = if (selected) PrimaryBlue.copy(alpha = 0.08f) else Color.Transparent,
-            contentColor = if (selected) PrimaryBlue else TextSecondary
+            containerColor = if (selected) colorScheme.surfaceVariant else Color.Transparent,
+            contentColor = if (selected) colorScheme.onSurface else colorScheme.onSurfaceVariant
         ),
         border = androidx.compose.foundation.BorderStroke(
             width = 1.dp,
-            color = if (selected) PrimaryBlue else Border
+            color = if (selected) colorScheme.primary else Border
         )
     ) {
         Text(

--- a/app/src/main/java/com/wheels/app/features/auth/presentation/ui/ForgotPasswordScreen.kt
+++ b/app/src/main/java/com/wheels/app/features/auth/presentation/ui/ForgotPasswordScreen.kt
@@ -54,11 +54,12 @@ fun ForgotPasswordScreen(
     val state by viewModel.uiState.collectAsState()
     val errorMessage = state.errorMessage
     val successMessage = state.successMessage
+    val colorScheme = MaterialTheme.colorScheme
 
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(Brush.verticalGradient(listOf(Color(0xFFE8F0F9), WheelsSurface)))
+            .background(Brush.verticalGradient(listOf(colorScheme.surfaceVariant, colorScheme.background)))
             .padding(innerPadding)
             .verticalScroll(rememberScrollState())
             .padding(horizontal = 24.dp, vertical = 16.dp)
@@ -67,7 +68,7 @@ fun ForgotPasswordScreen(
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                 contentDescription = "Back",
-                tint = PrimaryBlue
+                tint = colorScheme.onBackground
             )
         }
 
@@ -91,13 +92,13 @@ fun ForgotPasswordScreen(
             Text(
                 text = "Forgot Password",
                 style = MaterialTheme.typography.headlineMedium.copy(fontWeight = FontWeight.Bold),
-                color = PrimaryBlue
+                color = colorScheme.onBackground
             )
             Spacer(modifier = Modifier.height(8.dp))
             Text(
                 text = "Enter your university email and we will send recovery instructions.",
                 style = MaterialTheme.typography.bodyMedium,
-                color = TextSecondary,
+                color = colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center
             )
         }
@@ -165,8 +166,8 @@ fun ForgotPasswordScreen(
                         .height(56.dp),
                     shape = RoundedCornerShape(16.dp),
                     colors = ButtonDefaults.buttonColors(
-                        containerColor = PrimaryBlue,
-                        contentColor = WheelsSurface,
+                        containerColor = colorScheme.primary,
+                        contentColor = colorScheme.onPrimary,
                         disabledContainerColor = Border,
                         disabledContentColor = TextSecondary
                     )
@@ -175,7 +176,7 @@ fun ForgotPasswordScreen(
                         CircularProgressIndicator(
                             modifier = Modifier.size(20.dp),
                             strokeWidth = 2.dp,
-                            color = WheelsSurface
+                            color = colorScheme.onPrimary
                         )
                     } else {
                         Text(
@@ -190,7 +191,7 @@ fun ForgotPasswordScreen(
                 Text(
                     text = "Back to Sign In",
                     style = MaterialTheme.typography.bodyMedium,
-                    color = TextSecondary,
+                    color = colorScheme.onSurfaceVariant,
                     textAlign = TextAlign.Center,
                     modifier = Modifier
                         .fillMaxWidth()

--- a/app/src/main/java/com/wheels/app/features/auth/presentation/ui/SignInScreen.kt
+++ b/app/src/main/java/com/wheels/app/features/auth/presentation/ui/SignInScreen.kt
@@ -55,11 +55,12 @@ fun SignInScreen(
 ) {
     val state by viewModel.uiState.collectAsState()
     val errorMessage = state.errorMessage
+    val colorScheme = MaterialTheme.colorScheme
 
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(Brush.verticalGradient(listOf(Color(0xFFE8F0F9), WheelsSurface)))
+            .background(Brush.verticalGradient(listOf(colorScheme.surfaceVariant, colorScheme.background)))
             .padding(innerPadding)
             .verticalScroll(rememberScrollState())
             .padding(horizontal = 24.dp, vertical = 16.dp)
@@ -68,7 +69,7 @@ fun SignInScreen(
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                 contentDescription = "Back",
-                tint = PrimaryBlue
+                tint = colorScheme.onBackground
             )
         }
 
@@ -92,13 +93,13 @@ fun SignInScreen(
             Text(
                 text = "Welcome Back",
                 style = MaterialTheme.typography.headlineMedium.copy(fontWeight = FontWeight.Bold),
-                color = PrimaryBlue
+                color = colorScheme.onBackground
             )
             Spacer(modifier = Modifier.height(8.dp))
             Text(
                 text = "Sign in to continue to Wheels",
                 style = MaterialTheme.typography.bodyMedium,
-                color = TextSecondary,
+                color = colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center
             )
         }
@@ -187,8 +188,8 @@ fun SignInScreen(
                         .height(56.dp),
                     shape = RoundedCornerShape(16.dp),
                     colors = ButtonDefaults.buttonColors(
-                        containerColor = PrimaryBlue,
-                        contentColor = WheelsSurface,
+                        containerColor = colorScheme.primary,
+                        contentColor = colorScheme.onPrimary,
                         disabledContainerColor = Border,
                         disabledContentColor = TextSecondary
                     )
@@ -197,7 +198,7 @@ fun SignInScreen(
                         CircularProgressIndicator(
                             modifier = Modifier.size(20.dp),
                             strokeWidth = 2.dp,
-                            color = WheelsSurface
+                            color = colorScheme.onPrimary
                         )
                     } else {
                         Text(
@@ -212,7 +213,7 @@ fun SignInScreen(
                 Text(
                     text = "Don't have an account? Sign Up",
                     style = MaterialTheme.typography.bodySmall,
-                    color = TextSecondary,
+                    color = colorScheme.onSurfaceVariant,
                     textAlign = TextAlign.Center,
                     modifier = Modifier.fillMaxWidth()
                 )

--- a/app/src/main/java/com/wheels/app/features/auth/presentation/ui/WheelsInputField.kt
+++ b/app/src/main/java/com/wheels/app/features/auth/presentation/ui/WheelsInputField.kt
@@ -9,13 +9,10 @@ import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
-import com.wheels.app.core.ui.theme.PrimaryBlue
-import com.wheels.app.core.ui.theme.WheelsSurface
 
 @Composable
 fun WheelsInputField(
@@ -27,18 +24,20 @@ fun WheelsInputField(
     keyboardType: KeyboardType = KeyboardType.Text,
     visualTransformation: VisualTransformation = VisualTransformation.None
 ) {
+    val colorScheme = MaterialTheme.colorScheme
+
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         Text(
             text = label,
             style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.SemiBold),
-            color = PrimaryBlue
+            color = colorScheme.onSurface
         )
         OutlinedTextField(
             value = value,
             onValueChange = onValueChange,
             modifier = Modifier.fillMaxWidth(),
             placeholder = {
-                Text(text = placeholder, color = Color(0xFF94A3B8))
+                Text(text = placeholder, color = colorScheme.onSurfaceVariant.copy(alpha = 0.8f))
             },
             singleLine = true,
             shape = androidx.compose.foundation.shape.RoundedCornerShape(18.dp),
@@ -46,11 +45,17 @@ fun WheelsInputField(
             keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(keyboardType = keyboardType),
             visualTransformation = visualTransformation,
             colors = OutlinedTextFieldDefaults.colors(
-                unfocusedContainerColor = WheelsSurface,
-                focusedContainerColor = WheelsSurface,
-                unfocusedBorderColor = Color(0xFFE5E9F2),
-                focusedBorderColor = Color(0xFF5B89C8),
-                cursorColor = PrimaryBlue
+                focusedTextColor = colorScheme.onSurface,
+                unfocusedTextColor = colorScheme.onSurface,
+                disabledTextColor = colorScheme.onSurfaceVariant,
+                focusedContainerColor = colorScheme.surface,
+                unfocusedContainerColor = colorScheme.surface,
+                disabledContainerColor = colorScheme.surface,
+                focusedBorderColor = colorScheme.primary,
+                unfocusedBorderColor = colorScheme.outline,
+                focusedLabelColor = colorScheme.primary,
+                unfocusedLabelColor = colorScheme.onSurfaceVariant,
+                cursorColor = colorScheme.primary
             )
         )
     }

--- a/app/src/main/java/com/wheels/app/features/home/presentation/ui/HomeScreen.kt
+++ b/app/src/main/java/com/wheels/app/features/home/presentation/ui/HomeScreen.kt
@@ -60,11 +60,15 @@ import androidx.navigation.NavController
 import com.wheels.app.core.navigation.Destinations
 import com.wheels.app.core.ui.theme.Border
 import com.wheels.app.core.ui.theme.ElectricGreen
+import com.wheels.app.core.ui.theme.GradientHeaderIconContainer
+import com.wheels.app.core.ui.theme.GradientHeaderPrimaryContent
+import com.wheels.app.core.ui.theme.GradientHeaderSecondaryContent
 import com.wheels.app.core.ui.theme.PrimaryBlue
 import com.wheels.app.core.ui.theme.SecondaryBlue
 import com.wheels.app.core.ui.theme.TextSecondary
 import com.wheels.app.core.ui.theme.WheelsBackground
 import com.wheels.app.core.ui.theme.WheelsSurface
+import com.wheels.app.core.ui.theme.gradientHeaderBrush
 import com.wheels.app.features.home.presentation.viewmodel.ActiveRideUiModel
 import com.wheels.app.features.home.presentation.viewmodel.FrequentDestinationUiModel
 import com.wheels.app.features.home.presentation.viewmodel.HomeQuickStat
@@ -230,7 +234,7 @@ private fun HeaderSection(state: HomeUiState) {
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(bottomStart = 24.dp, bottomEnd = 24.dp))
-            .background(Brush.linearGradient(listOf(PrimaryBlue, Color(0xFF2D5280))))
+            .background(gradientHeaderBrush())
             .padding(horizontal = 20.dp, vertical = 18.dp)
             .padding(top = 20.dp)
     ) {
@@ -240,12 +244,12 @@ private fun HeaderSection(state: HomeUiState) {
             verticalAlignment = Alignment.CenterVertically
         ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                Surface(shape = CircleShape, color = WheelsSurface.copy(alpha = 0.10f)) {
+                Surface(shape = CircleShape, color = GradientHeaderIconContainer) {
                     IconButton(onClick = {}) {
                         Icon(
                             imageVector = Icons.Default.Menu,
                             contentDescription = "Menu",
-                            tint = WheelsSurface
+                            tint = GradientHeaderPrimaryContent
                         )
                     }
                 }
@@ -254,23 +258,23 @@ private fun HeaderSection(state: HomeUiState) {
                     Text(
                         text = state.welcomeMessage,
                         style = MaterialTheme.typography.bodySmall,
-                        color = WheelsSurface.copy(alpha = 0.72f)
+                        color = GradientHeaderSecondaryContent
                     )
                     Text(
                         text = state.userName,
                         style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
-                        color = WheelsSurface
+                        color = GradientHeaderPrimaryContent
                     )
                 }
             }
 
             Box(contentAlignment = Alignment.TopEnd) {
-                Surface(shape = CircleShape, color = WheelsSurface.copy(alpha = 0.10f)) {
+                Surface(shape = CircleShape, color = GradientHeaderIconContainer) {
                     IconButton(onClick = {}) {
                         Icon(
                             imageVector = Icons.Default.Notifications,
                             contentDescription = "Notifications",
-                            tint = WheelsSurface
+                            tint = GradientHeaderPrimaryContent
                         )
                     }
                 }
@@ -302,25 +306,27 @@ private fun StatChip(stat: HomeQuickStat, modifier: Modifier = Modifier) {
     Column(
         modifier = modifier
             .clip(RoundedCornerShape(16.dp))
-            .background(WheelsSurface.copy(alpha = 0.10f))
+            .background(GradientHeaderIconContainer)
             .padding(vertical = 12.dp, horizontal = 8.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(
             text = stat.value,
             style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
-            color = stat.accentColor ?: WheelsSurface
+            color = stat.accentColor ?: GradientHeaderPrimaryContent
         )
         Text(
             text = stat.label,
             style = MaterialTheme.typography.bodySmall,
-            color = WheelsSurface.copy(alpha = 0.70f)
+            color = GradientHeaderSecondaryContent
         )
     }
 }
 
 @Composable
 private fun MapSection(activeRide: ActiveRideUiModel) {
+    val colorScheme = MaterialTheme.colorScheme
+
     Card(
         modifier = Modifier
             .padding(horizontal = 16.dp)
@@ -333,7 +339,7 @@ private fun MapSection(activeRide: ActiveRideUiModel) {
             modifier = Modifier
                 .fillMaxWidth()
                 .height(260.dp)
-                .background(Brush.linearGradient(listOf(Color(0xFFE8F0F9), WheelsBackground)))
+                .background(Brush.linearGradient(listOf(Color(0xFF102033), Color(0xFF17283E))))
         ) {
             MapGridBackground()
             RoutePath()
@@ -384,7 +390,7 @@ private fun MapSection(activeRide: ActiveRideUiModel) {
                     Icon(
                         imageVector = Icons.Outlined.MyLocation,
                         contentDescription = "Center map",
-                        tint = PrimaryBlue
+                        tint = colorScheme.onSurface
                     )
                 }
             }
@@ -395,7 +401,7 @@ private fun MapSection(activeRide: ActiveRideUiModel) {
 @Composable
 private fun MapGridBackground() {
     Canvas(modifier = Modifier.fillMaxSize()) {
-        val gridColor = SecondaryBlue.copy(alpha = 0.18f)
+        val gridColor = Color(0xFF5B89C8).copy(alpha = 0.24f)
         val verticalStops = listOf(size.width * 0.25f, size.width * 0.5f, size.width * 0.75f)
         val horizontalStops = listOf(size.height * 0.25f, size.height * 0.5f, size.height * 0.75f)
         verticalStops.forEach { x ->
@@ -411,7 +417,7 @@ private fun MapGridBackground() {
 private fun RoutePath() {
     Canvas(modifier = Modifier.fillMaxSize()) {
         drawLine(
-            color = SecondaryBlue.copy(alpha = 0.60f),
+            color = Color(0xFF60A5FA).copy(alpha = 0.82f),
             start = Offset(size.width * 0.20f, size.height * 0.78f),
             end = Offset(size.width * 0.82f, size.height * 0.22f),
             strokeWidth = 8f,

--- a/app/src/main/java/com/wheels/app/features/payments/presentation/ui/PaymentsScreen.kt
+++ b/app/src/main/java/com/wheels/app/features/payments/presentation/ui/PaymentsScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Surface
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -21,14 +22,26 @@ fun PaymentsScreen(
 ) {
     val state by viewModel.uiState.collectAsState()
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(innerPadding),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background
     ) {
-        Text(text = "Pagos", style = MaterialTheme.typography.headlineMedium)
-        Text(text = "Monto pendiente: COP ${state.pendingAmount}")
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "Pagos",
+                style = MaterialTheme.typography.headlineMedium,
+                color = MaterialTheme.colorScheme.onBackground
+            )
+            Text(
+                text = "Monto pendiente: COP ${state.pendingAmount}",
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
     }
 }

--- a/app/src/main/java/com/wheels/app/features/payments/presentation/ui/QuickPaymentScreen.kt
+++ b/app/src/main/java/com/wheels/app/features/payments/presentation/ui/QuickPaymentScreen.kt
@@ -52,18 +52,19 @@ import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import com.wheels.app.core.ui.theme.Border
 import com.wheels.app.core.ui.theme.ElectricGreen
+import com.wheels.app.core.ui.theme.GradientHeaderPrimaryContent
+import com.wheels.app.core.ui.theme.GradientHeaderSecondaryContent
 import com.wheels.app.core.ui.theme.PrimaryBlue
 import com.wheels.app.core.ui.theme.SecondaryBlue
 import com.wheels.app.core.ui.theme.TextSecondary
 import com.wheels.app.core.ui.theme.WheelsBackground
 import com.wheels.app.core.ui.theme.WheelsSurface
+import com.wheels.app.core.ui.theme.gradientHeaderBrush
 import com.wheels.app.features.payments.presentation.viewmodel.PaymentsViewModel
 import java.text.NumberFormat
 import java.util.Locale
 
 private val SelectionBlue = Color(0xFF5B89C8)
-private val SelectionBackground = Color(0xFFE8F0F9)
-
 data class PaymentMethod(
     val id: String,
     val name: String,
@@ -171,7 +172,7 @@ private fun HeaderSection(navController: NavController) {
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(bottomStart = 24.dp, bottomEnd = 24.dp))
-            .background(Brush.linearGradient(listOf(PrimaryBlue, Color(0xFF2D5280))))
+            .background(gradientHeaderBrush())
                 .padding(horizontal = 20.dp, vertical = 30.dp)
     ) {
         Row(
@@ -188,7 +189,7 @@ private fun HeaderSection(navController: NavController) {
                 Icon(
                     imageVector = Icons.Outlined.ChevronLeft,
                     contentDescription = "Back",
-                    tint = WheelsSurface,
+                    tint = GradientHeaderPrimaryContent,
                     modifier = Modifier
                         .width(20.dp)
                         .height(20.dp)
@@ -196,7 +197,7 @@ private fun HeaderSection(navController: NavController) {
                 Text(
                     text = "Back",
                     style = MaterialTheme.typography.bodySmall,
-                    color = WheelsSurface,
+                    color = GradientHeaderPrimaryContent,
                     fontWeight = FontWeight.Medium
                 )
             }
@@ -208,12 +209,12 @@ private fun HeaderSection(navController: NavController) {
             Text(
                 text = "Quick Payment",
                 style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
-                color = WheelsSurface
+                color = GradientHeaderPrimaryContent
             )
             Text(
                 text = "Fast and secure ride payment",
                 style = MaterialTheme.typography.bodySmall,
-                color = WheelsSurface.copy(alpha = 0.8f)
+                color = GradientHeaderSecondaryContent
             )
         }
 
@@ -411,6 +412,8 @@ private fun PaymentMethodCard(
     onSelect: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val colorScheme = MaterialTheme.colorScheme
+
     Surface(
         modifier = modifier
             .clip(RoundedCornerShape(20.dp))
@@ -420,7 +423,7 @@ private fun PaymentMethodCard(
                 color = if (isSelected) SelectionBlue else Border,
                 shape = RoundedCornerShape(20.dp)
             ),
-        color = if (isSelected) SelectionBackground else WheelsSurface,
+        color = if (isSelected) colorScheme.surfaceVariant else WheelsSurface,
         shape = RoundedCornerShape(20.dp)
     ) {
         Row(
@@ -436,7 +439,7 @@ private fun PaymentMethodCard(
                     .height(48.dp)
                     .clip(CircleShape)
                     .background(
-                        if (isSelected) SelectionBlue else WheelsBackground
+                        if (isSelected) SelectionBlue else colorScheme.surfaceVariant
                     ),
                 contentAlignment = Alignment.Center
             ) {
@@ -454,13 +457,13 @@ private fun PaymentMethodCard(
                 Text(
                     text = method.name,
                     style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
-                    color = PrimaryBlue
+                    color = colorScheme.onSurface
                 )
                 if (method.details != null) {
                     Text(
                         text = method.details,
                         style = MaterialTheme.typography.bodySmall,
-                        color = if (method.id == "wallet") ElectricGreen else TextSecondary
+                        color = if (method.id == "wallet") ElectricGreen else colorScheme.onSurfaceVariant
                     )
                 }
             }
@@ -475,7 +478,7 @@ private fun PaymentMethodCard(
                         color = if (isSelected) SelectionBlue else Border,
                         shape = CircleShape
                     )
-                    .background(if (isSelected) SelectionBlue else WheelsSurface),
+                    .background(if (isSelected) SelectionBlue else colorScheme.surface),
                 contentAlignment = Alignment.Center
             ) {
                 if (isSelected) {

--- a/app/src/main/java/com/wheels/app/features/profile/presentation/ui/ProfileScreen.kt
+++ b/app/src/main/java/com/wheels/app/features/profile/presentation/ui/ProfileScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.outlined.StarBorder
 import androidx.compose.material.icons.outlined.CardGiftcard
 import androidx.compose.material.icons.outlined.CreditCard
 import androidx.compose.material.icons.outlined.Notifications
+import androidx.compose.material.icons.outlined.Palette
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.Logout
 import androidx.compose.material.icons.outlined.ChevronRight
@@ -438,41 +439,6 @@ fun ProfileScreen(
                             onClick = { navController.navigate(Destinations.TrustFairness.route) },
                             showDivider = true
                         )
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(top = 12.dp, bottom = 16.dp),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Column(modifier = Modifier.weight(1f)) {
-                                Text(
-                                    text = "Trust & Fairness Theme",
-                                    fontSize = 12.sp,
-                                    fontWeight = FontWeight.Medium,
-                                    color = Color(0xFF1a3a5c)
-                                )
-                                Text(
-                                    text = if (state.trustFairnessDarkMode) "Dark mode enabled" else "Light mode enabled",
-                                    fontSize = 10.sp,
-                                    color = Color(0xFF64748b)
-                                )
-                            }
-                            TextButton(
-                                onClick = { viewModel.onEvent(ProfileEvent.ToggleTrustFairnessDarkMode) }
-                            ) {
-                                Text(
-                                    text = if (state.trustFairnessDarkMode) "Use Light" else "Use Dark",
-                                    color = Color(0xFF1a3a5c),
-                                    fontWeight = FontWeight.SemiBold
-                                )
-                            }
-                        }
-                        Divider(
-                            color = Color(0xFFe5e9f2),
-                            thickness = 1.dp,
-                            modifier = Modifier.fillMaxWidth()
-                        )
                         MenuItemRow(
                             icon = Icons.Outlined.CreditCard,
                             title = "Payment Methods",
@@ -514,6 +480,13 @@ fun ProfileScreen(
                         .padding(20.dp)
                 ) {
                     Column {
+                        MenuItemRow(
+                            icon = Icons.Outlined.Palette,
+                            title = "UI Theme",
+                            subtitle = "Adjust dark mode and adaptive appearance",
+                            onClick = { navController.navigate(Destinations.UiTheme.route) },
+                            showDivider = true
+                        )
                         MenuItemRow(
                             icon = Icons.Outlined.Notifications,
                             title = "Notifications",

--- a/app/src/main/java/com/wheels/app/features/profile/presentation/ui/ProfileScreen.kt
+++ b/app/src/main/java/com/wheels/app/features/profile/presentation/ui/ProfileScreen.kt
@@ -65,11 +65,12 @@ fun ProfileScreen(
     navController: NavController
 ) {
     val state by viewModel.uiState.collectAsState()
+    val colorScheme = MaterialTheme.colorScheme
 
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(Color(0xFFF7F9FC))
+            .background(colorScheme.background)
     ) {
         LazyColumn(
             modifier = Modifier
@@ -124,7 +125,7 @@ fun ProfileScreen(
                             ambientColor = Color(0xFF1a3a5c).copy(alpha = 0.12f)
                         )
                         .clip(RoundedCornerShape(24.dp))
-                        .background(Color.White)
+                        .background(colorScheme.surface)
                         .padding(24.dp)
                 ) {
                     Column {
@@ -172,7 +173,7 @@ fun ProfileScreen(
                                     text = state.name,
                                     fontSize = 18.sp,
                                     fontWeight = FontWeight.Bold,
-                                    color = Color(0xFF1a3a5c),
+                                    color = colorScheme.onSurface,
                                     modifier = Modifier.padding(bottom = 8.dp)
                                 )
 
@@ -198,7 +199,7 @@ fun ProfileScreen(
                                 Text(
                                     text = state.memberSinceLabel,
                                     fontSize = 12.sp,
-                                    color = Color(0xFF64748b)
+                                    color = colorScheme.onSurfaceVariant
                                 )
 
                                 Spacer(modifier = Modifier.height(16.dp))
@@ -232,7 +233,7 @@ fun ProfileScreen(
                                     Text(
                                         text = roleInfoMessage,
                                         fontSize = 12.sp,
-                                        color = Color(0xFF64748b)
+                                        color = colorScheme.onSurfaceVariant
                                     )
                                 }
 
@@ -243,7 +244,7 @@ fun ProfileScreen(
                                         modifier = Modifier
                                             .fillMaxWidth()
                                             .clip(RoundedCornerShape(16.dp))
-                                            .background(Color(0xFFF7F9FC))
+                                            .background(colorScheme.surfaceVariant)
                                             .padding(12.dp),
                                         verticalArrangement = Arrangement.spacedBy(10.dp)
                                     ) {
@@ -251,12 +252,12 @@ fun ProfileScreen(
                                             text = "Enable ${roleUpgradeTarget.displayName} role",
                                             fontSize = 14.sp,
                                             fontWeight = FontWeight.SemiBold,
-                                            color = Color(0xFF1a3a5c)
+                                            color = colorScheme.onSurface
                                         )
                                         Text(
                                             text = "Confirm your password and we'll add this role to your account.",
                                             fontSize = 12.sp,
-                                            color = Color(0xFF64748b)
+                                            color = colorScheme.onSurfaceVariant
                                         )
                                         OutlinedTextField(
                                             value = state.roleUpgradePassword,
@@ -335,7 +336,7 @@ fun ProfileScreen(
                                     modifier = Modifier
                                         .weight(1f)
                                         .clip(RoundedCornerShape(16.dp))
-                                        .background(Color(0xFFF7F9FC))
+                                        .background(colorScheme.surfaceVariant)
                                         .padding(12.dp),
                                     contentAlignment = Alignment.Center
                                 ) {
@@ -349,7 +350,7 @@ fun ProfileScreen(
                                         Text(
                                             text = label,
                                             fontSize = 10.sp,
-                                            color = Color(0xFF64748b)
+                                            color = colorScheme.onSurfaceVariant
                                         )
                                     }
                                 }
@@ -367,7 +368,7 @@ fun ProfileScreen(
                     text = "Contact Information",
                     fontSize = 12.sp,
                     fontWeight = FontWeight.SemiBold,
-                    color = Color(0xFF64748b),
+                    color = colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(bottom = 12.dp)
                 )
 
@@ -380,7 +381,7 @@ fun ProfileScreen(
                             ambientColor = Color(0xFF1a3a5c).copy(alpha = 0.08f)
                         )
                         .clip(RoundedCornerShape(20.dp))
-                        .background(Color.White)
+                        .background(colorScheme.surface)
                         .padding(20.dp)
                 ) {
                     Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
@@ -392,7 +393,7 @@ fun ProfileScreen(
                         )
 
                         Divider(
-                            color = Color(0xFFe5e9f2),
+                            color = colorScheme.outline,
                             thickness = 1.dp,
                             modifier = Modifier.fillMaxWidth()
                         )
@@ -415,7 +416,7 @@ fun ProfileScreen(
                     text = "Account",
                     fontSize = 12.sp,
                     fontWeight = FontWeight.SemiBold,
-                    color = Color(0xFF64748b),
+                    color = colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(bottom = 12.dp)
                 )
 
@@ -428,7 +429,7 @@ fun ProfileScreen(
                             ambientColor = Color(0xFF1a3a5c).copy(alpha = 0.08f)
                         )
                         .clip(RoundedCornerShape(20.dp))
-                        .background(Color.White)
+                        .background(colorScheme.surface)
                         .padding(20.dp)
                 ) {
                     Column {
@@ -463,7 +464,7 @@ fun ProfileScreen(
                     text = "Settings",
                     fontSize = 12.sp,
                     fontWeight = FontWeight.SemiBold,
-                    color = Color(0xFF64748b),
+                    color = colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(bottom = 12.dp)
                 )
 
@@ -476,7 +477,7 @@ fun ProfileScreen(
                             ambientColor = Color(0xFF1a3a5c).copy(alpha = 0.08f)
                         )
                         .clip(RoundedCornerShape(20.dp))
-                        .background(Color.White)
+                        .background(colorScheme.surface)
                         .padding(20.dp)
                 ) {
                     Column {
@@ -521,8 +522,8 @@ fun ProfileScreen(
                         shape = RoundedCornerShape(20.dp),
                         ambientColor = Color(0xFF1a3a5c).copy(alpha = 0.08f)
                     )
-                    .border(2.dp, Color(0xFFe5e9f2), RoundedCornerShape(20.dp))
-                    .background(Color.White, RoundedCornerShape(20.dp))
+                    .border(2.dp, colorScheme.outline, RoundedCornerShape(20.dp))
+                    .background(colorScheme.surface, RoundedCornerShape(20.dp))
                     .clickable { viewModel.onEvent(ProfileEvent.LogOut) }
                     .padding(16.dp),
                 contentAlignment = Alignment.Center
@@ -563,15 +564,17 @@ private fun RoleSwitchButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val colorScheme = MaterialTheme.colorScheme
+
     Box(
         modifier = modifier
             .clip(RoundedCornerShape(14.dp))
             .background(
-                if (selected) Color(0xFF1a3a5c) else if (enabled) Color(0xFFF7F9FC) else Color(0xFFF1F5F9)
+                if (selected) colorScheme.primary else if (enabled) colorScheme.surfaceVariant else colorScheme.outline.copy(alpha = 0.2f)
             )
             .border(
                 width = 1.5.dp,
-                color = if (selected) Color(0xFF1a3a5c) else Color(0xFFE2E8F0),
+                color = if (selected) colorScheme.primary else colorScheme.outline,
                 shape = RoundedCornerShape(14.dp)
             )
             .clickable(onClick = onClick)
@@ -582,7 +585,7 @@ private fun RoleSwitchButton(
             text = label,
             fontSize = 13.sp,
             fontWeight = FontWeight.SemiBold,
-            color = if (selected) Color.White else if (enabled) Color(0xFF64748b) else Color(0xFF94A3B8)
+            color = if (selected) colorScheme.onPrimary else if (enabled) colorScheme.onSurfaceVariant else colorScheme.onSurfaceVariant.copy(alpha = 0.65f)
         )
     }
 }
@@ -593,6 +596,8 @@ fun ContactInfoRow(
     label: String,
     value: String
 ) {
+    val colorScheme = MaterialTheme.colorScheme
+
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(12.dp),
@@ -602,13 +607,13 @@ fun ContactInfoRow(
             modifier = Modifier
                 .size(40.dp)
                 .clip(CircleShape)
-                .background(Color(0xFFe8f0f9)),
+                .background(colorScheme.surfaceVariant),
             contentAlignment = Alignment.Center
         ) {
             Icon(
                 imageVector = icon,
                 contentDescription = label,
-                tint = Color(0xFF5b89c8),
+                tint = colorScheme.primary,
                 modifier = Modifier.size(20.dp)
             )
         }
@@ -621,20 +626,20 @@ fun ContactInfoRow(
             Text(
                 text = label,
                 fontSize = 10.sp,
-                color = Color(0xFF64748b)
+                color = colorScheme.onSurfaceVariant
             )
             Text(
                 text = value,
                 fontSize = 12.sp,
                 fontWeight = FontWeight.Medium,
-                color = Color(0xFF1a3a5c)
+                color = colorScheme.onSurface
             )
         }
 
         Icon(
             imageVector = Icons.Outlined.ChevronRight,
             contentDescription = "Navigate",
-            tint = Color(0xFF64748b),
+            tint = colorScheme.onSurfaceVariant,
             modifier = Modifier.size(20.dp)
         )
     }
@@ -648,6 +653,8 @@ fun MenuItemRow(
     onClick: () -> Unit = {},
     showDivider: Boolean = false
 ) {
+    val colorScheme = MaterialTheme.colorScheme
+
     Column {
         Row(
             modifier = Modifier
@@ -661,13 +668,13 @@ fun MenuItemRow(
                 modifier = Modifier
                     .size(40.dp)
                     .clip(CircleShape)
-                    .background(Color(0xFFe8f0f9)),
+                    .background(colorScheme.surfaceVariant),
                 contentAlignment = Alignment.Center
             ) {
                 Icon(
                     imageVector = icon,
                     contentDescription = title,
-                    tint = Color(0xFF5b89c8),
+                    tint = colorScheme.primary,
                     modifier = Modifier.size(20.dp)
                 )
             }
@@ -681,26 +688,26 @@ fun MenuItemRow(
                     text = title,
                     fontSize = 13.sp,
                     fontWeight = FontWeight.Medium,
-                    color = Color(0xFF1a3a5c)
+                    color = colorScheme.onSurface
                 )
                 Text(
                     text = subtitle,
                     fontSize = 11.sp,
-                    color = Color(0xFF64748b)
+                    color = colorScheme.onSurfaceVariant
                 )
             }
 
             Icon(
                 imageVector = Icons.Outlined.ChevronRight,
                 contentDescription = "Navigate",
-                tint = Color(0xFF64748b),
+                tint = colorScheme.onSurfaceVariant,
                 modifier = Modifier.size(20.dp)
             )
         }
 
         if (showDivider) {
             Divider(
-                color = Color(0xFFe5e9f2),
+                color = colorScheme.outline,
                 thickness = 1.dp,
                 modifier = Modifier.fillMaxWidth()
             )

--- a/app/src/main/java/com/wheels/app/features/profile/presentation/ui/TrustFairnessScreen.kt
+++ b/app/src/main/java/com/wheels/app/features/profile/presentation/ui/TrustFairnessScreen.kt
@@ -32,11 +32,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import com.wheels.app.core.session.UserRole
+import com.wheels.app.core.ui.theme.GradientHeaderPrimaryContent
+import com.wheels.app.core.ui.theme.GradientHeaderSecondaryContent
 import com.wheels.app.features.profile.presentation.viewmodel.ProfileViewModel
 
 @Composable
@@ -46,24 +49,25 @@ fun TrustFairnessScreen(
     viewModel: ProfileViewModel
 ) {
     val state by viewModel.uiState.collectAsState()
-    val colors = if (state.trustFairnessDarkMode) {
+    val colorScheme = MaterialTheme.colorScheme
+    val colors = if (colorScheme.background.luminance() < 0.5f) {
         TrustFairnessPalette(
-            background = Color(0xFF0F172A),
-            surface = Color(0xFF111827),
+            background = colorScheme.background,
+            surface = colorScheme.surface,
             primary = Color(0xFFBFDBFE),
-            textPrimary = Color(0xFFF8FAFC),
-            textSecondary = Color(0xFFCBD5E1),
+            textPrimary = colorScheme.onSurface,
+            textSecondary = colorScheme.onSurfaceVariant,
             success = Color(0xFF34D399),
             warning = Color(0xFFFBBF24),
             danger = Color(0xFFF87171)
         )
     } else {
         TrustFairnessPalette(
-            background = Color(0xFFF7F9FC),
-            surface = Color.White,
+            background = colorScheme.background,
+            surface = colorScheme.surface,
             primary = Color(0xFF1A3A5C),
-            textPrimary = Color(0xFF1A3A5C),
-            textSecondary = Color(0xFF64748B),
+            textPrimary = colorScheme.onSurface,
+            textSecondary = colorScheme.onSurfaceVariant,
             success = Color(0xFF00D9A3),
             warning = Color(0xFFFFA726),
             danger = Color(0xFFEF4444)
@@ -85,26 +89,26 @@ fun TrustFairnessScreen(
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .background(colors.primary, RoundedCornerShape(bottomStart = 24.dp, bottomEnd = 24.dp))
+                        .background(Color(0xFF1A3A5C), RoundedCornerShape(bottomStart = 24.dp, bottomEnd = 24.dp))
                         .padding(start = 12.dp, end = 20.dp, top = 28.dp, bottom = 24.dp)
                 ) {
                     IconButton(onClick = { navController.popBackStack() }) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = "Back",
-                            tint = colors.surface
+                            tint = GradientHeaderPrimaryContent
                         )
                     }
                     Text(
                         text = "Trust & Fairness",
-                        color = colors.surface,
+                        color = GradientHeaderPrimaryContent,
                         fontSize = 22.sp,
                         fontWeight = FontWeight.Bold
                     )
                     Spacer(modifier = Modifier.height(6.dp))
                     Text(
                         text = "Current contract for reliability score, cancellations and community accountability.",
-                        color = colors.surface.copy(alpha = 0.85f),
+                        color = GradientHeaderSecondaryContent,
                         fontSize = 12.sp
                     )
                 }

--- a/app/src/main/java/com/wheels/app/features/profile/presentation/ui/UiThemeScreen.kt
+++ b/app/src/main/java/com/wheels/app/features/profile/presentation/ui/UiThemeScreen.kt
@@ -52,6 +52,7 @@ fun UiThemeScreen(
 ) {
     val themeState = viewModel.uiState.collectAsStateWithLifecycle()
     val darkModeEnabled = themeState.value.isDarkModeEnabled
+    val adaptiveThemeEnabled = themeState.value.isAdaptiveThemeEnabled
     val colorScheme = MaterialTheme.colorScheme
 
     Box(
@@ -131,7 +132,7 @@ fun UiThemeScreen(
                             title = "Dark mode",
                             subtitle = if (darkModeEnabled) "Enabled" else "Disabled",
                             checked = darkModeEnabled,
-                            enabled = true,
+                            enabled = !adaptiveThemeEnabled,
                             onCheckedChange = viewModel::setDarkModeEnabled
                         )
 
@@ -144,10 +145,10 @@ fun UiThemeScreen(
                         ThemeSwitchRow(
                             icon = Icons.Outlined.WbSunny,
                             title = "Adaptive UI Theme",
-                            subtitle = "Coming soon. Dark mode is manual for now.",
-                            checked = false,
-                            enabled = false,
-                            onCheckedChange = {}
+                            subtitle = "The UI Theme adapts to the environmental light.",
+                            checked = adaptiveThemeEnabled,
+                            enabled = true,
+                            onCheckedChange = viewModel::setAdaptiveThemeEnabled
                         )
                     }
                 }

--- a/app/src/main/java/com/wheels/app/features/profile/presentation/ui/UiThemeScreen.kt
+++ b/app/src/main/java/com/wheels/app/features/profile/presentation/ui/UiThemeScreen.kt
@@ -1,0 +1,242 @@
+package com.wheels.app.features.profile.presentation.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ChevronLeft
+import androidx.compose.material.icons.outlined.DarkMode
+import androidx.compose.material.icons.outlined.LightMode
+import androidx.compose.material.icons.outlined.WbSunny
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Divider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+
+@Composable
+fun UiThemeScreen(
+    innerPadding: PaddingValues,
+    navController: NavController
+) {
+    var darkModeEnabled by remember { mutableStateOf(false) }
+    var adaptiveThemeEnabled by remember { mutableStateOf(false) }
+    var savedDarkModePreference by remember { mutableStateOf(false) }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color(0xFFF7F9FC))
+    ) {
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            item {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp)
+                        .clip(RoundedCornerShape(bottomStart = 24.dp, bottomEnd = 24.dp))
+                        .background(
+                            brush = Brush.linearGradient(
+                                colors = listOf(
+                                    Color(0xFF1a3a5c),
+                                    Color(0xFF2d5280)
+                                )
+                            )
+                        )
+                        .padding(start = 24.dp, end = 24.dp, top = 36.dp, bottom = 20.dp)
+                ) {
+                    Column {
+                        Row(
+                            modifier = Modifier
+                                .clickable { navController.popBackStack() },
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(4.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Outlined.ChevronLeft,
+                                contentDescription = "Back",
+                                tint = Color.White,
+                                modifier = Modifier
+                                    .size(20.dp)
+                            )
+                            Text(
+                                text = "Back",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = Color.White,
+                                fontWeight = FontWeight.Medium
+                            )
+                        }
+
+                        Spacer(modifier = Modifier.height(20.dp))
+
+                        Text(
+                            text = "UI Theme",
+                            fontSize = 22.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = Color.White,
+                            modifier = Modifier.padding(bottom = 8.dp)
+                        )
+                        Text(
+                            text = "Dark mode can reduce bright blues and may feel better for vision under low light conditions.",
+                            fontSize = 12.sp,
+                            color = Color.White.copy(alpha = 0.8f)
+                        )
+                    }
+                }
+            }
+
+            item {
+                Card(
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp)
+                        .fillMaxWidth(),
+                    shape = RoundedCornerShape(20.dp),
+                    colors = CardDefaults.cardColors(containerColor = Color.White),
+                    elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+                ) {
+                    Column(modifier = Modifier.padding(20.dp)) {
+                        ThemeSwitchRow(
+                            icon = if (darkModeEnabled) Icons.Outlined.DarkMode else Icons.Outlined.LightMode,
+                            title = "Dark mode",
+                            subtitle = if (darkModeEnabled) "Enabled" else "Disabled",
+                            checked = darkModeEnabled,
+                            enabled = !adaptiveThemeEnabled,
+                            onCheckedChange = { checked ->
+                                if (!adaptiveThemeEnabled) {
+                                    darkModeEnabled = checked
+                                    savedDarkModePreference = checked
+                                }
+                            }
+                        )
+
+                        Divider(
+                            color = Color(0xFFe5e9f2),
+                            thickness = 1.dp,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+
+                        ThemeSwitchRow(
+                            icon = Icons.Outlined.WbSunny,
+                            title = "Adaptive UI Theme",
+                            subtitle = "The UI Theme adapts to the environmental light.",
+                            checked = adaptiveThemeEnabled,
+                            enabled = true,
+                            onCheckedChange = { checked ->
+                                if (checked) {
+                                    savedDarkModePreference = darkModeEnabled
+                                    darkModeEnabled = false
+                                } else {
+                                    darkModeEnabled = savedDarkModePreference
+                                }
+                                adaptiveThemeEnabled = checked
+                            }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ThemeSwitchRow(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    title: String,
+    subtitle: String,
+    checked: Boolean,
+    enabled: Boolean,
+    onCheckedChange: (Boolean) -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(RoundedCornerShape(20.dp))
+                .background(if (enabled) Color(0xFFe8f0f9) else Color(0xFFEEF2F7)),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = title,
+                tint = if (enabled) Color(0xFF5b89c8) else Color(0xFF9AA9BC),
+                modifier = Modifier.size(20.dp)
+            )
+        }
+
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Text(
+                text = title,
+                fontSize = 13.sp,
+                fontWeight = FontWeight.Medium,
+                color = if (enabled) Color(0xFF1a3a5c) else Color(0xFF8FA1B6)
+            )
+            Text(
+                text = subtitle,
+                fontSize = 11.sp,
+                color = if (enabled) Color(0xFF64748b) else Color(0xFFA0AEC0)
+            )
+        }
+
+        Switch(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+            enabled = enabled,
+            colors = SwitchDefaults.colors(
+                checkedThumbColor = Color.White,
+                uncheckedThumbColor = Color.White,
+                checkedTrackColor = Color(0xFF5b89c8),
+                uncheckedTrackColor = Color(0xFFD7E0EC),
+                uncheckedBorderColor = Color(0xFFD7E0EC),
+                disabledCheckedThumbColor = Color(0xFFE2E8F0),
+                disabledUncheckedThumbColor = Color(0xFFE2E8F0),
+                disabledCheckedTrackColor = Color(0xFFC8D3E2),
+                disabledUncheckedTrackColor = Color(0xFFDEE6F0),
+                disabledUncheckedBorderColor = Color(0xFFDEE6F0),
+                disabledCheckedBorderColor = Color(0xFFC8D3E2)
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/wheels/app/features/profile/presentation/ui/UiThemeScreen.kt
+++ b/app/src/main/java/com/wheels/app/features/profile/presentation/ui/UiThemeScreen.kt
@@ -29,10 +29,6 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -41,21 +37,27 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
+import com.wheels.app.core.ui.theme.GradientHeaderPrimaryContent
+import com.wheels.app.core.ui.theme.GradientHeaderSecondaryContent
+import com.wheels.app.core.theme.ThemeSettingsViewModel
+import com.wheels.app.core.ui.theme.gradientHeaderBrush
 
 @Composable
 fun UiThemeScreen(
     innerPadding: PaddingValues,
-    navController: NavController
+    navController: NavController,
+    viewModel: ThemeSettingsViewModel
 ) {
-    var darkModeEnabled by remember { mutableStateOf(false) }
-    var adaptiveThemeEnabled by remember { mutableStateOf(false) }
-    var savedDarkModePreference by remember { mutableStateOf(false) }
+    val themeState = viewModel.uiState.collectAsStateWithLifecycle()
+    val darkModeEnabled = themeState.value.isDarkModeEnabled
+    val colorScheme = MaterialTheme.colorScheme
 
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(Color(0xFFF7F9FC))
+            .background(colorScheme.background)
     ) {
         LazyColumn(
             modifier = Modifier
@@ -70,12 +72,7 @@ fun UiThemeScreen(
                         .height(200.dp)
                         .clip(RoundedCornerShape(bottomStart = 24.dp, bottomEnd = 24.dp))
                         .background(
-                            brush = Brush.linearGradient(
-                                colors = listOf(
-                                    Color(0xFF1a3a5c),
-                                    Color(0xFF2d5280)
-                                )
-                            )
+                            brush = gradientHeaderBrush()
                         )
                         .padding(start = 24.dp, end = 24.dp, top = 36.dp, bottom = 20.dp)
                 ) {
@@ -89,14 +86,14 @@ fun UiThemeScreen(
                             Icon(
                                 imageVector = Icons.Outlined.ChevronLeft,
                                 contentDescription = "Back",
-                                tint = Color.White,
+                                tint = GradientHeaderPrimaryContent,
                                 modifier = Modifier
                                     .size(20.dp)
                             )
                             Text(
                                 text = "Back",
                                 style = MaterialTheme.typography.bodySmall,
-                                color = Color.White,
+                                color = GradientHeaderPrimaryContent,
                                 fontWeight = FontWeight.Medium
                             )
                         }
@@ -107,13 +104,13 @@ fun UiThemeScreen(
                             text = "UI Theme",
                             fontSize = 22.sp,
                             fontWeight = FontWeight.Bold,
-                            color = Color.White,
+                            color = GradientHeaderPrimaryContent,
                             modifier = Modifier.padding(bottom = 8.dp)
                         )
                         Text(
                             text = "Dark mode can reduce bright blues and may feel better for vision under low light conditions.",
                             fontSize = 12.sp,
-                            color = Color.White.copy(alpha = 0.8f)
+                            color = GradientHeaderSecondaryContent
                         )
                     }
                 }
@@ -125,7 +122,7 @@ fun UiThemeScreen(
                         .padding(horizontal = 16.dp)
                         .fillMaxWidth(),
                     shape = RoundedCornerShape(20.dp),
-                    colors = CardDefaults.cardColors(containerColor = Color.White),
+                    colors = CardDefaults.cardColors(containerColor = colorScheme.surface),
                     elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
                 ) {
                     Column(modifier = Modifier.padding(20.dp)) {
@@ -134,17 +131,12 @@ fun UiThemeScreen(
                             title = "Dark mode",
                             subtitle = if (darkModeEnabled) "Enabled" else "Disabled",
                             checked = darkModeEnabled,
-                            enabled = !adaptiveThemeEnabled,
-                            onCheckedChange = { checked ->
-                                if (!adaptiveThemeEnabled) {
-                                    darkModeEnabled = checked
-                                    savedDarkModePreference = checked
-                                }
-                            }
+                            enabled = true,
+                            onCheckedChange = viewModel::setDarkModeEnabled
                         )
 
                         Divider(
-                            color = Color(0xFFe5e9f2),
+                            color = colorScheme.outline,
                             thickness = 1.dp,
                             modifier = Modifier.fillMaxWidth()
                         )
@@ -152,18 +144,10 @@ fun UiThemeScreen(
                         ThemeSwitchRow(
                             icon = Icons.Outlined.WbSunny,
                             title = "Adaptive UI Theme",
-                            subtitle = "The UI Theme adapts to the environmental light.",
-                            checked = adaptiveThemeEnabled,
-                            enabled = true,
-                            onCheckedChange = { checked ->
-                                if (checked) {
-                                    savedDarkModePreference = darkModeEnabled
-                                    darkModeEnabled = false
-                                } else {
-                                    darkModeEnabled = savedDarkModePreference
-                                }
-                                adaptiveThemeEnabled = checked
-                            }
+                            subtitle = "Coming soon. Dark mode is manual for now.",
+                            checked = false,
+                            enabled = false,
+                            onCheckedChange = {}
                         )
                     }
                 }
@@ -181,6 +165,8 @@ private fun ThemeSwitchRow(
     enabled: Boolean,
     onCheckedChange: (Boolean) -> Unit
 ) {
+    val colorScheme = MaterialTheme.colorScheme
+
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -192,13 +178,13 @@ private fun ThemeSwitchRow(
             modifier = Modifier
                 .size(40.dp)
                 .clip(RoundedCornerShape(20.dp))
-                .background(if (enabled) Color(0xFFe8f0f9) else Color(0xFFEEF2F7)),
+                .background(if (enabled) colorScheme.surfaceVariant else colorScheme.outline.copy(alpha = 0.2f)),
             contentAlignment = Alignment.Center
         ) {
             Icon(
                 imageVector = icon,
                 contentDescription = title,
-                tint = if (enabled) Color(0xFF5b89c8) else Color(0xFF9AA9BC),
+                tint = if (enabled) colorScheme.primary else colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
                 modifier = Modifier.size(20.dp)
             )
         }
@@ -211,12 +197,12 @@ private fun ThemeSwitchRow(
                 text = title,
                 fontSize = 13.sp,
                 fontWeight = FontWeight.Medium,
-                color = if (enabled) Color(0xFF1a3a5c) else Color(0xFF8FA1B6)
+                color = if (enabled) colorScheme.onSurface else colorScheme.onSurfaceVariant.copy(alpha = 0.65f)
             )
             Text(
                 text = subtitle,
                 fontSize = 11.sp,
-                color = if (enabled) Color(0xFF64748b) else Color(0xFFA0AEC0)
+                color = if (enabled) colorScheme.onSurfaceVariant else colorScheme.onSurfaceVariant.copy(alpha = 0.65f)
             )
         }
 
@@ -225,17 +211,17 @@ private fun ThemeSwitchRow(
             onCheckedChange = onCheckedChange,
             enabled = enabled,
             colors = SwitchDefaults.colors(
-                checkedThumbColor = Color.White,
-                uncheckedThumbColor = Color.White,
-                checkedTrackColor = Color(0xFF5b89c8),
-                uncheckedTrackColor = Color(0xFFD7E0EC),
-                uncheckedBorderColor = Color(0xFFD7E0EC),
-                disabledCheckedThumbColor = Color(0xFFE2E8F0),
-                disabledUncheckedThumbColor = Color(0xFFE2E8F0),
-                disabledCheckedTrackColor = Color(0xFFC8D3E2),
-                disabledUncheckedTrackColor = Color(0xFFDEE6F0),
-                disabledUncheckedBorderColor = Color(0xFFDEE6F0),
-                disabledCheckedBorderColor = Color(0xFFC8D3E2)
+                checkedThumbColor = colorScheme.onPrimary,
+                uncheckedThumbColor = colorScheme.surface,
+                checkedTrackColor = colorScheme.primary,
+                uncheckedTrackColor = colorScheme.outline.copy(alpha = 0.35f),
+                uncheckedBorderColor = colorScheme.outline,
+                disabledCheckedThumbColor = colorScheme.surface,
+                disabledUncheckedThumbColor = colorScheme.surface,
+                disabledCheckedTrackColor = colorScheme.outline.copy(alpha = 0.5f),
+                disabledUncheckedTrackColor = colorScheme.outline.copy(alpha = 0.25f),
+                disabledUncheckedBorderColor = colorScheme.outline.copy(alpha = 0.7f),
+                disabledCheckedBorderColor = colorScheme.outline.copy(alpha = 0.7f)
             )
         )
     }

--- a/app/src/main/java/com/wheels/app/features/rides/presentation/ui/ReviewsRatingsScreen.kt
+++ b/app/src/main/java/com/wheels/app/features/rides/presentation/ui/ReviewsRatingsScreen.kt
@@ -42,16 +42,20 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.wheels.app.core.ui.theme.Border
 import com.wheels.app.core.ui.theme.ElectricGreen
+import com.wheels.app.core.ui.theme.GradientHeaderPrimaryContent
+import com.wheels.app.core.ui.theme.GradientHeaderSecondaryContent
 import com.wheels.app.core.ui.theme.PrimaryBlue
 import com.wheels.app.core.ui.theme.SecondaryBlue
 import com.wheels.app.core.ui.theme.TextSecondary
 import com.wheels.app.core.ui.theme.WheelsBackground
 import com.wheels.app.core.ui.theme.WheelsSurface
+import com.wheels.app.core.ui.theme.gradientHeaderBrush
 
 private data class ReviewItem(
     val id: Int,
@@ -136,6 +140,8 @@ fun ReviewsRatingsScreen(
     navController: NavController,
     driverName: String
 ) {
+    val colorScheme = MaterialTheme.colorScheme
+
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
@@ -167,7 +173,7 @@ fun ReviewsRatingsScreen(
                     .clickable { },
                 shape = RoundedCornerShape(16.dp),
                 color = WheelsSurface,
-                border = androidx.compose.foundation.BorderStroke(2.dp, Color(0xFFE5E9F2))
+                border = androidx.compose.foundation.BorderStroke(2.dp, colorScheme.outline)
             ) {
                 Box(
                     modifier = Modifier.padding(vertical = 12.dp),
@@ -190,7 +196,7 @@ private fun ReviewsHeader(driverName: String, onBack: () -> Unit) {
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(bottomStart = 24.dp, bottomEnd = 24.dp))
-            .background(Brush.linearGradient(listOf(PrimaryBlue, Color(0xFF2D5280))))
+            .background(gradientHeaderBrush())
             .padding(horizontal = 20.dp, vertical = 18.dp)
             .padding(top = 20.dp)
     ) {
@@ -205,14 +211,14 @@ private fun ReviewsHeader(driverName: String, onBack: () -> Unit) {
             Icon(
                 imageVector = Icons.Outlined.ChevronLeft,
                 contentDescription = "Back",
-                tint = WheelsSurface,
+                tint = GradientHeaderPrimaryContent,
                 modifier = Modifier
                     .width(20.dp)
                     .height(20.dp)
             )
             Text(
                 text = "Back",
-                color = WheelsSurface.copy(alpha = 0.84f),
+                color = GradientHeaderSecondaryContent,
                 style = MaterialTheme.typography.bodyMedium
             )
         }
@@ -222,13 +228,13 @@ private fun ReviewsHeader(driverName: String, onBack: () -> Unit) {
         Text(
             text = "Reviews and Ratings",
             style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
-            color = WheelsSurface
+            color = GradientHeaderPrimaryContent
         )
         Spacer(modifier = Modifier.height(4.dp))
         Text(
             text = "$driverName profile",
             style = MaterialTheme.typography.bodyMedium,
-            color = WheelsSurface.copy(alpha = 0.82f)
+            color = GradientHeaderSecondaryContent
         )
         Spacer(modifier = Modifier.height(18.dp))
     }
@@ -236,6 +242,8 @@ private fun ReviewsHeader(driverName: String, onBack: () -> Unit) {
 
 @Composable
 private fun RatingSummaryCard(driverName: String) {
+    val colorScheme = MaterialTheme.colorScheme
+
     Card(
         modifier = Modifier
             .padding(horizontal = 16.dp)
@@ -292,7 +300,7 @@ private fun RatingSummaryCard(driverName: String) {
                                     .weight(1f)
                                     .height(6.dp)
                                     .clip(RoundedCornerShape(999.dp))
-                                    .background(Color(0xFFE8F0F9))
+                                    .background(colorScheme.surfaceVariant)
                             ) {
                                 Box(
                                     modifier = Modifier
@@ -379,9 +387,11 @@ private fun MetricBox(
     value: String,
     modifier: Modifier = Modifier
 ) {
+    val colorScheme = MaterialTheme.colorScheme
+
     Surface(
         modifier = modifier,
-        color = WheelsBackground,
+        color = colorScheme.surfaceVariant,
         shape = RoundedCornerShape(16.dp)
     ) {
         Column(modifier = Modifier.padding(12.dp)) {
@@ -450,6 +460,8 @@ private fun FiltersRow() {
 
 @Composable
 private fun ReviewCard(review: ReviewItem) {
+    val colorScheme = MaterialTheme.colorScheme
+
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -528,11 +540,11 @@ private fun ReviewCard(review: ReviewItem) {
                 review.tags.forEach { tag ->
                     Surface(
                         shape = RoundedCornerShape(999.dp),
-                        color = Color(0xFFE8F0F9)
+                        color = colorScheme.surfaceVariant
                     ) {
                         Text(
                             text = tag,
-                            color = SecondaryBlue,
+                            color = if (colorScheme.background.luminance() < 0.5f) colorScheme.onSurface else SecondaryBlue,
                             style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Medium),
                             modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp)
                         )

--- a/app/src/main/java/com/wheels/app/features/rides/presentation/ui/RideRequestScreen.kt
+++ b/app/src/main/java/com/wheels/app/features/rides/presentation/ui/RideRequestScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.window.Dialog
@@ -64,12 +65,15 @@ import androidx.navigation.NavController
 import com.wheels.app.core.navigation.Destinations
 import com.wheels.app.core.ui.theme.Border
 import com.wheels.app.core.ui.theme.ElectricGreen
+import com.wheels.app.core.ui.theme.GradientHeaderPrimaryContent
+import com.wheels.app.core.ui.theme.GradientHeaderSecondaryContent
 import com.wheels.app.core.ui.theme.PrimaryBlue
 import com.wheels.app.core.ui.theme.SecondaryBlue
 import com.wheels.app.core.ui.theme.TextSecondary
 import com.wheels.app.core.ui.theme.Warning
 import com.wheels.app.core.ui.theme.WheelsBackground
 import com.wheels.app.core.ui.theme.WheelsSurface
+import com.wheels.app.core.ui.theme.gradientHeaderBrush
 import com.wheels.app.features.rides.presentation.viewmodel.RideRequestEvent
 import com.wheels.app.features.rides.presentation.viewmodel.RideRequestUiModel
 import com.wheels.app.features.rides.presentation.viewmodel.RideRequestUiState
@@ -190,7 +194,7 @@ private fun RideRequestHeader(
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(bottomStart = 24.dp, bottomEnd = 24.dp))
-            .background(Brush.linearGradient(listOf(PrimaryBlue, Color(0xFF2D5280))))
+            .background(gradientHeaderBrush())
             .padding(horizontal = 20.dp, vertical = 18.dp)
             .padding(top = 20.dp)
     ) {
@@ -201,13 +205,13 @@ private fun RideRequestHeader(
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                 contentDescription = "Back to rides",
-                tint = WheelsSurface,
+                tint = GradientHeaderPrimaryContent,
                 modifier = Modifier.size(20.dp)
             )
             Spacer(modifier = Modifier.width(8.dp))
             Text(
                 text = "Back to rides",
-                color = WheelsSurface.copy(alpha = 0.82f),
+                color = GradientHeaderSecondaryContent,
                 style = MaterialTheme.typography.bodyMedium
             )
         }
@@ -217,12 +221,12 @@ private fun RideRequestHeader(
         Text(
             text = "Ride Details",
             style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
-            color = WheelsSurface
+            color = GradientHeaderPrimaryContent
         )
         Spacer(modifier = Modifier.height(4.dp))
         Text(
             text = "${ride.departureDate} at ${ride.departureTime}",
-            color = WheelsSurface.copy(alpha = 0.82f),
+            color = GradientHeaderSecondaryContent,
             style = MaterialTheme.typography.bodyMedium
         )
     }
@@ -230,6 +234,8 @@ private fun RideRequestHeader(
 
 @Composable
 private fun MapPreviewCard(ride: RideRequestUiModel) {
+    val colorScheme = MaterialTheme.colorScheme
+
     Card(
         modifier = Modifier
             .padding(horizontal = 16.dp)
@@ -242,10 +248,10 @@ private fun MapPreviewCard(ride: RideRequestUiModel) {
             modifier = Modifier
                 .fillMaxWidth()
                 .height(192.dp)
-                .background(Brush.linearGradient(listOf(Color(0xFFE8F0F9), WheelsBackground)))
+                .background(Brush.linearGradient(listOf(Color(0xFF102033), Color(0xFF17283E))))
         ) {
             Canvas(modifier = Modifier.fillMaxSize()) {
-                val gridColor = SecondaryBlue.copy(alpha = 0.18f)
+                val gridColor = Color(0xFF5B89C8).copy(alpha = 0.24f)
                 val verticalStops = listOf(size.width * 0.25f, size.width * 0.5f, size.width * 0.75f)
                 val horizontalStops = listOf(size.height * 0.25f, size.height * 0.5f, size.height * 0.75f)
                 verticalStops.forEach { x ->
@@ -256,7 +262,7 @@ private fun MapPreviewCard(ride: RideRequestUiModel) {
                 }
 
                 drawLine(
-                    color = SecondaryBlue.copy(alpha = 0.8f),
+                    color = Color(0xFF60A5FA).copy(alpha = 0.85f),
                     start = Offset(size.width * 0.20f, size.height * 0.82f),
                     end = Offset(size.width * 0.80f, size.height * 0.20f),
                     strokeWidth = 8f,
@@ -295,7 +301,7 @@ private fun MapPreviewCard(ride: RideRequestUiModel) {
             ) {
                 Text(
                     text = ride.distance,
-                    color = PrimaryBlue,
+                    color = colorScheme.onSurface,
                     style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
                     modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp)
                 )
@@ -479,6 +485,8 @@ private fun SeatSelectionCard(
     totalPrice: Int,
     onSeatSelected: (Int) -> Unit
 ) {
+    val colorScheme = MaterialTheme.colorScheme
+
     InfoCard(title = "Select Seats", trailingLabel = "${ride.availableSeats} available") {
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             (1..ride.availableSeats).forEach { seat ->
@@ -508,7 +516,7 @@ private fun SeatSelectionCard(
 
         Surface(
             shape = RoundedCornerShape(16.dp),
-            color = Color(0xFFE8F0F9)
+            color = colorScheme.surfaceVariant
         ) {
             Column(modifier = Modifier.padding(16.dp)) {
                 SummaryRow("Price per seat", "$${ride.price}")
@@ -525,6 +533,8 @@ private fun SeatSelectionCard(
 
 @Composable
 private fun RideInformationCard(ride: RideRequestUiModel) {
+    val colorScheme = MaterialTheme.colorScheme
+
     InfoCard(title = "Ride Information") {
         if (ride.amenities.isNotEmpty()) {
             Text(
@@ -537,11 +547,11 @@ private fun RideInformationCard(ride: RideRequestUiModel) {
                 ride.amenities.forEach { amenity ->
                     Surface(
                         shape = RoundedCornerShape(999.dp),
-                        color = Color(0xFFE8F0F9)
+                        color = colorScheme.surfaceVariant
                     ) {
                         Text(
                             text = amenity,
-                            color = SecondaryBlue,
+                            color = if (colorScheme.background.luminance() < 0.5f) colorScheme.onSurface else SecondaryBlue,
                             style = MaterialTheme.typography.bodySmall.copy(fontWeight = FontWeight.Medium),
                             modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)
                         )
@@ -575,10 +585,12 @@ private fun RideInformationCard(ride: RideRequestUiModel) {
 
 @Composable
 private fun SafetyNoteCard() {
+    val colorScheme = MaterialTheme.colorScheme
+
     Surface(
         modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
         shape = RoundedCornerShape(20.dp),
-        color = Color(0xFFE8F0F9)
+        color = colorScheme.surfaceVariant
     ) {
         Row(modifier = Modifier.padding(16.dp), verticalAlignment = Alignment.Top) {
             Icon(
@@ -875,7 +887,7 @@ private fun SmallAction(
     icon: androidx.compose.ui.graphics.vector.ImageVector,
     contentDescription: String
 ) {
-    Surface(shape = CircleShape, color = Color(0xFFE8F0F9)) {
+    Surface(shape = CircleShape, color = MaterialTheme.colorScheme.surfaceVariant) {
         IconButton(onClick = {}) {
             Icon(
                 imageVector = icon,
@@ -920,6 +932,8 @@ private fun SummaryRow(
     value: String,
     emphasized: Boolean = false
 ) {
+    val colorScheme = MaterialTheme.colorScheme
+
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
@@ -927,7 +941,7 @@ private fun SummaryRow(
     ) {
         Text(
             text = label,
-            color = if (emphasized) PrimaryBlue else TextSecondary,
+            color = if (emphasized) colorScheme.onSurface else colorScheme.onSurfaceVariant,
             style = if (emphasized) {
                 MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold)
             } else {
@@ -936,7 +950,7 @@ private fun SummaryRow(
         )
         Text(
             text = value,
-            color = PrimaryBlue,
+            color = colorScheme.onSurface,
             style = if (emphasized) {
                 MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
             } else {

--- a/app/src/main/java/com/wheels/app/features/rides/presentation/ui/RidesScreen.kt
+++ b/app/src/main/java/com/wheels/app/features/rides/presentation/ui/RidesScreen.kt
@@ -67,6 +67,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -76,11 +77,14 @@ import com.wheels.app.core.navigation.Destinations
 import com.wheels.app.core.session.UserRole
 import com.wheels.app.core.ui.theme.Border
 import com.wheels.app.core.ui.theme.ElectricGreen
+import com.wheels.app.core.ui.theme.GradientHeaderPrimaryContent
+import com.wheels.app.core.ui.theme.GradientHeaderSecondaryContent
 import com.wheels.app.core.ui.theme.PrimaryBlue
 import com.wheels.app.core.ui.theme.SecondaryBlue
 import com.wheels.app.core.ui.theme.TextSecondary
 import com.wheels.app.core.ui.theme.WheelsBackground
 import com.wheels.app.core.ui.theme.WheelsSurface
+import com.wheels.app.core.ui.theme.gradientHeaderBrush
 import com.wheels.app.features.rides.domain.model.BehavioralNudge
 import com.wheels.app.features.rides.presentation.model.LocationSuggestion
 import com.wheels.app.features.rides.presentation.model.RideLocationField
@@ -770,7 +774,7 @@ private fun DriverTabSwitcher(
         modifier = modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(16.dp))
-            .background(Color(0xFFE8F0F9))
+            .background(MaterialTheme.colorScheme.surfaceVariant)
             .padding(4.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
@@ -796,10 +800,12 @@ private fun DriverTabButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val colorScheme = MaterialTheme.colorScheme
+
     Surface(
         modifier = modifier.clickable(onClick = onClick),
         shape = RoundedCornerShape(12.dp),
-        color = if (selected) WheelsSurface else Color.Transparent
+        color = if (selected) colorScheme.surface else Color.Transparent
     ) {
         Box(
             modifier = Modifier.padding(vertical = 12.dp),
@@ -808,7 +814,7 @@ private fun DriverTabButton(
             Text(
                 text = text,
                 style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
-                color = if (selected) PrimaryBlue else TextSecondary
+                color = if (selected) colorScheme.onSurface else colorScheme.onSurfaceVariant
             )
         }
     }
@@ -993,11 +999,12 @@ private fun DriverRideCard(
 
 @Composable
 private fun DriverRideStatusChip(status: DriverRideStatus) {
+    val isDark = MaterialTheme.colorScheme.background.luminance() < 0.5f
     val (label, backgroundColor, textColor) = when (status) {
-        DriverRideStatus.PENDING -> Triple("Pending", Color(0xFFFEF3C7), Color(0xFFF59E0B))
-        DriverRideStatus.ACTIVE -> Triple("Active", Color(0xFFD1FAE5), ElectricGreen)
-        DriverRideStatus.COMPLETED -> Triple("Completed", Color(0xFFE2E8F0), PrimaryBlue)
-        DriverRideStatus.CANCELLED -> Triple("Cancelled", Color(0xFFFEE2E2), Color(0xFFDC2626))
+        DriverRideStatus.PENDING -> Triple("Pending", if (isDark) Color(0xFF3A2E11) else Color(0xFFFEF3C7), Color(0xFFF59E0B))
+        DriverRideStatus.ACTIVE -> Triple("Active", if (isDark) Color(0xFF123126) else Color(0xFFD1FAE5), ElectricGreen)
+        DriverRideStatus.COMPLETED -> Triple("Completed", if (isDark) Color(0xFF1E293B) else Color(0xFFE2E8F0), if (isDark) Color(0xFFBFDBFE) else PrimaryBlue)
+        DriverRideStatus.CANCELLED -> Triple("Cancelled", if (isDark) Color(0xFF3F1D1D) else Color(0xFFFEE2E2), Color(0xFFDC2626))
     }
 
     Surface(
@@ -1019,7 +1026,7 @@ private fun CreateRideHeader(onBack: () -> Unit) {
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(bottomStart = 24.dp, bottomEnd = 24.dp))
-            .background(Brush.linearGradient(listOf(PrimaryBlue, Color(0xFF2D5280))))
+            .background(gradientHeaderBrush())
             .padding(horizontal = 20.dp, vertical = 18.dp)
             .padding(top = 20.dp)
     ) {
@@ -1033,13 +1040,13 @@ private fun CreateRideHeader(onBack: () -> Unit) {
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                     contentDescription = "Back",
-                    tint = WheelsSurface,
+                    tint = GradientHeaderPrimaryContent,
                     modifier = Modifier.size(20.dp)
                 )
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
                     text = "Back",
-                    color = WheelsSurface.copy(alpha = 0.84f),
+                    color = GradientHeaderSecondaryContent,
                     style = MaterialTheme.typography.bodyMedium
                 )
             }
@@ -1050,13 +1057,13 @@ private fun CreateRideHeader(onBack: () -> Unit) {
         Text(
             text = "Create a Ride",
             style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
-            color = WheelsSurface
+            color = GradientHeaderPrimaryContent
         )
         Spacer(modifier = Modifier.height(4.dp))
         Text(
             text = "Publish your ride and earn money",
             style = MaterialTheme.typography.bodyMedium,
-            color = WheelsSurface.copy(alpha = 0.84f)
+            color = GradientHeaderSecondaryContent
         )
     }
 }
@@ -1260,7 +1267,7 @@ private fun RidesHeader(onBack: () -> Unit) {
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(bottomStart = 24.dp, bottomEnd = 24.dp))
-            .background(Brush.linearGradient(listOf(PrimaryBlue, Color(0xFF2D5280))))
+            .background(gradientHeaderBrush())
             .padding(horizontal = 20.dp, vertical = 18.dp)
             .padding(top = 20.dp)
     ) {
@@ -1274,13 +1281,13 @@ private fun RidesHeader(onBack: () -> Unit) {
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                 contentDescription = "Back",
-                tint = WheelsSurface,
+                tint = GradientHeaderPrimaryContent,
                 modifier = Modifier.size(20.dp)
             )
             Spacer(modifier = Modifier.width(8.dp))
             Text(
                 text = "Back",
-                color = WheelsSurface.copy(alpha = 0.84f),
+                color = GradientHeaderSecondaryContent,
                 style = MaterialTheme.typography.bodyMedium
             )
         }
@@ -1290,13 +1297,13 @@ private fun RidesHeader(onBack: () -> Unit) {
         Text(
             text = "Find a Ride",
             style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
-            color = WheelsSurface
+            color = GradientHeaderPrimaryContent
         )
         Spacer(modifier = Modifier.height(4.dp))
         Text(
             text = "Available rides from your university",
             style = MaterialTheme.typography.bodyMedium,
-            color = WheelsSurface.copy(alpha = 0.82f)
+            color = GradientHeaderSecondaryContent
         )
     }
 }


### PR DESCRIPTION
This pull request introduces a user-selectable dark mode to the app, with persistent theme preferences and improved Material 3 theming throughout the UI. It adds a new `ThemeSettingsViewModel` and `ThemePreferencesRepository` for managing and storing the dark mode setting, updates navigation and screens to support theme switching, and refactors color usage to leverage the Material 3 color system for better consistency and support for both light and dark themes.

**Dark mode support and theme settings:**
- Added `ThemeSettingsViewModel` and `ThemePreferencesRepository` to manage and persist the user's dark mode preference using `DataStore`, and updated `MainActivity` to provide the theme state throughout the app. [[1]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46R73) [[2]](diffhunk://#diff-f0cc9fd90049a847d0da02e312aad727603b68eebc395a8bb4c5f3e50d8c069eR6-R9) [[3]](diffhunk://#diff-f0cc9fd90049a847d0da02e312aad727603b68eebc395a8bb4c5f3e50d8c069eL15-R22) [[4]](diffhunk://#diff-01c546281fab84bf34a507499a1da7b2a08e3a8c6951dcca2be1bf3445f13534R1-R35) [[5]](diffhunk://#diff-2a684f8dd8d80eb94805376beac020eeebb2d5c51afb99dd40d37b50c748be80R1-R35)
- Introduced a new navigation destination and screen (`UiThemeScreen`) for changing the UI theme, and wired it into the navigation graph. [[1]](diffhunk://#diff-43b92b6da219115640eac7ac5a21c994d34050da9433b407e093f3a89d781ac4R31) [[2]](diffhunk://#diff-06a3c6f74e8eb6248b52f19d368fbafc40a28d5b925a27faf1d0fa6b8d4a0407R18) [[3]](diffhunk://#diff-06a3c6f74e8eb6248b52f19d368fbafc40a28d5b925a27faf1d0fa6b8d4a0407R36) [[4]](diffhunk://#diff-06a3c6f74e8eb6248b52f19d368fbafc40a28d5b925a27faf1d0fa6b8d4a0407L46-R48) [[5]](diffhunk://#diff-06a3c6f74e8eb6248b52f19d368fbafc40a28d5b925a27faf1d0fa6b8d4a0407R232-R238)

**Material 3 theming and color system refactor:**
- Refactored color definitions in `Color.kt` to support both light and dark palettes, and updated the `WheelsTheme` to synchronize custom palette state with Material 3 color schemes. [[1]](diffhunk://#diff-f6240810f500dbb43a705de9010d90e7f0b7f502298bc5ee488a61115baed4dcR3-R53) [[2]](diffhunk://#diff-3787c4eb52cdff1e0b79f6bca356105af90937a9eff73d55d0c84cc46f4b4dddR8-R47)
- Updated UI components such as `WheelsBottomBar` and various screens to use `MaterialTheme.colorScheme` for colors instead of hardcoded values or custom color objects, ensuring consistent appearance in both themes. [[1]](diffhunk://#diff-46480bcb59f8514e3e3f73a71ab0f4c104509594bfbbcfe1b74788d3cbf9671eR21) [[2]](diffhunk://#diff-46480bcb59f8514e3e3f73a71ab0f4c104509594bfbbcfe1b74788d3cbf9671eL32-L35) [[3]](diffhunk://#diff-46480bcb59f8514e3e3f73a71ab0f4c104509594bfbbcfe1b74788d3cbf9671eR41-R51) [[4]](diffhunk://#diff-46480bcb59f8514e3e3f73a71ab0f4c104509594bfbbcfe1b74788d3cbf9671eR80-R81) [[5]](diffhunk://#diff-46480bcb59f8514e3e3f73a71ab0f4c104509594bfbbcfe1b74788d3cbf9671eL97-R98) [[6]](diffhunk://#diff-46480bcb59f8514e3e3f73a71ab0f4c104509594bfbbcfe1b74788d3cbf9671eR107-R112) [[7]](diffhunk://#diff-46480bcb59f8514e3e3f73a71ab0f4c104509594bfbbcfe1b74788d3cbf9671eR129-R149) [[8]](diffhunk://#diff-bc902f28cfdb9a70f9e0e12c7dbdb1d2fd61419bb90c42a4dd2c26ca505e51b8L17-R39) [[9]](diffhunk://#diff-5b699d1b18c61ae6c81c53c09a87df938a1eb7898f09bef320087178aa4a94c8R69-R74) [[10]](diffhunk://#diff-5b699d1b18c61ae6c81c53c09a87df938a1eb7898f09bef320087178aa4a94c8L90-R91)

**Other UI improvements:**
- Added a reusable gradient header brush and related color tokens for consistent header styling.

Closes #56 