### PR TITLE
Feature/time usage observer pattern #58

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ local.properties
 .vscode/
 MOCKUP-PASSENGER/
 DOCS/
+Flutter/
+Firebase-functions/
 
 # Keystore and secrets
 *.jks

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -69,6 +69,7 @@ dependencies {
     implementation("androidx.core:core-ktx:1.15.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.7")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.7")
+    implementation("androidx.lifecycle:lifecycle-process:2.8.7")
     implementation("androidx.activity:activity-compose:1.10.1")
     implementation("androidx.datastore:datastore-preferences:1.1.1")
 

--- a/app/src/main/java/com/wheels/app/MainActivity.kt
+++ b/app/src/main/java/com/wheels/app/MainActivity.kt
@@ -1,8 +1,13 @@
 package com.wheels.app
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.compose.setContent
+import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.wheels.app.core.navigation.WheelsNavGraph
@@ -12,8 +17,15 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    private val notificationPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+    ) { /* No-op: the service checks permission before posting notifications. */ }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        requestNotificationPermissionIfNeeded()
+
         setContent {
             val themeViewModel: ThemeSettingsViewModel = hiltViewModel()
             val themeState = themeViewModel.uiState.collectAsStateWithLifecycle()
@@ -22,5 +34,21 @@ class MainActivity : ComponentActivity() {
                 WheelsNavGraph(themeViewModel = themeViewModel)
             }
         }
+    }
+
+    private fun requestNotificationPermissionIfNeeded() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+        if (
+            ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.POST_NOTIFICATIONS,
+            ) == PackageManager.PERMISSION_GRANTED
+        ) {
+            return
+        }
+
+        // Request once when the main app shell opens so incoming FCM messages
+        // can be rendered without coupling permission flow to messaging service code.
+        notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
     }
 }

--- a/app/src/main/java/com/wheels/app/WheelsApplication.kt
+++ b/app/src/main/java/com/wheels/app/WheelsApplication.kt
@@ -1,13 +1,21 @@
 package com.wheels.app
 
 import android.app.Application
+import androidx.lifecycle.ProcessLifecycleOwner
+import com.wheels.app.core.behavior.AppForegroundLifecycleObserver
 import com.google.firebase.FirebaseApp
 import dagger.hilt.android.HiltAndroidApp
+import javax.inject.Inject
 
 @HiltAndroidApp
 class WheelsApplication : Application() {
+
+    @Inject
+    lateinit var appForegroundLifecycleObserver: AppForegroundLifecycleObserver
+
     override fun onCreate() {
         super.onCreate()
         FirebaseApp.initializeApp(this)
+        ProcessLifecycleOwner.get().lifecycle.addObserver(appForegroundLifecycleObserver)
     }
 }

--- a/app/src/main/java/com/wheels/app/core/behavior/AppForegroundLifecycleObserver.kt
+++ b/app/src/main/java/com/wheels/app/core/behavior/AppForegroundLifecycleObserver.kt
@@ -1,0 +1,41 @@
+package com.wheels.app.core.behavior
+
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import com.google.firebase.auth.FirebaseAuth
+import com.wheels.app.core.behavior.domain.event.AppOpenSource
+import com.wheels.app.core.behavior.domain.model.AppOpenIdentity
+import com.wheels.app.core.behavior.domain.usecase.TrackAppOpenUseCase
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+@Singleton
+class AppForegroundLifecycleObserver @Inject constructor(
+    private val firebaseAuth: FirebaseAuth,
+    private val trackAppOpenUseCase: TrackAppOpenUseCase
+) : DefaultLifecycleObserver {
+
+    private val observerScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    override fun onStart(owner: LifecycleOwner) {
+        // Foreground opens are only tracked for signed-in users, so every event
+        // can be tied to Firestore usage data and the user's FCM tokens later.
+        val currentUser = firebaseAuth.currentUser ?: return
+        val email = currentUser.email.orEmpty()
+        if (email.isBlank()) return
+
+        observerScope.launch {
+            trackAppOpenUseCase(
+                identity = AppOpenIdentity(
+                    uid = currentUser.uid,
+                    email = email
+                ),
+                source = AppOpenSource.FOREGROUND
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/wheels/app/core/behavior/AppOpenEventDebouncer.kt
+++ b/app/src/main/java/com/wheels/app/core/behavior/AppOpenEventDebouncer.kt
@@ -1,0 +1,31 @@
+package com.wheels.app.core.behavior
+
+import android.os.SystemClock
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AppOpenEventDebouncer @Inject constructor() {
+
+    private val lastPublishedByUser = ConcurrentHashMap<String, Long>()
+
+    fun shouldPublish(uid: String): Boolean {
+        if (uid.isBlank()) return false
+
+        val nowElapsed = SystemClock.elapsedRealtime()
+        val lastPublishedAt = lastPublishedByUser[uid]
+        if (lastPublishedAt != null && nowElapsed - lastPublishedAt < DEBOUNCE_WINDOW_MILLIS) {
+            return false
+        }
+
+        lastPublishedByUser[uid] = nowElapsed
+        return true
+    }
+
+    private companion object {
+        // A short window prevents login/session restore and foreground from
+        // double-counting the same launch cycle while keeping later opens valid.
+        const val DEBOUNCE_WINDOW_MILLIS = 5_000L
+    }
+}

--- a/app/src/main/java/com/wheels/app/core/behavior/data/bus/InMemoryEventBus.kt
+++ b/app/src/main/java/com/wheels/app/core/behavior/data/bus/InMemoryEventBus.kt
@@ -1,0 +1,39 @@
+package com.wheels.app.core.behavior.data.bus
+
+import com.wheels.app.core.behavior.domain.bus.EventBus
+import com.wheels.app.core.behavior.domain.event.AppEvent
+import com.wheels.app.core.behavior.domain.observer.AppEventSubscriber
+import java.util.concurrent.CopyOnWriteArraySet
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+
+@Singleton
+class InMemoryEventBus @Inject constructor(
+    subscribers: Set<@JvmSuppressWildcards AppEventSubscriber>,
+    private val ioDispatcher: CoroutineDispatcher
+) : EventBus {
+
+    private val subscribers = CopyOnWriteArraySet<AppEventSubscriber>()
+
+    init {
+        // Hilt provides the observer set, and the bus keeps the publish/subscribe
+        // relationship explicit to match the Observer pattern in the app layer.
+        subscribers.forEach(::subscribe)
+    }
+
+    override fun subscribe(subscriber: AppEventSubscriber) {
+        subscribers.add(subscriber)
+    }
+
+    override suspend fun publish(event: AppEvent) {
+        withContext(ioDispatcher) {
+            // Every subscriber receives the same event, but each one decides
+            // whether and how to react to it.
+            subscribers.forEach { subscriber ->
+                subscriber.update(event)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/wheels/app/core/behavior/data/bus/InMemoryEventBus.kt
+++ b/app/src/main/java/com/wheels/app/core/behavior/data/bus/InMemoryEventBus.kt
@@ -1,5 +1,6 @@
 package com.wheels.app.core.behavior.data.bus
 
+import android.util.Log
 import com.wheels.app.core.behavior.domain.bus.EventBus
 import com.wheels.app.core.behavior.domain.event.AppEvent
 import com.wheels.app.core.behavior.domain.observer.AppEventSubscriber
@@ -32,8 +33,18 @@ class InMemoryEventBus @Inject constructor(
             // Every subscriber receives the same event, but each one decides
             // whether and how to react to it.
             subscribers.forEach { subscriber ->
-                subscriber.update(event)
+                runCatching {
+                    subscriber.update(event)
+                }.onFailure { error ->
+                    // Observers are best-effort. One failing subscriber should
+                    // not crash the app or prevent the other observers from running.
+                    Log.w(TAG, "App event observer failed", error)
+                }
             }
         }
+    }
+
+    private companion object {
+        const val TAG = "InMemoryEventBus"
     }
 }

--- a/app/src/main/java/com/wheels/app/core/behavior/data/observer/AnalyticsObserver.kt
+++ b/app/src/main/java/com/wheels/app/core/behavior/data/observer/AnalyticsObserver.kt
@@ -1,0 +1,21 @@
+package com.wheels.app.core.behavior.data.observer
+
+import com.wheels.app.core.behavior.domain.event.AppEvent
+import com.wheels.app.core.behavior.domain.event.AppOpenedEvent
+import com.wheels.app.core.behavior.domain.observer.AppEventSubscriber
+import com.wheels.app.core.behavior.domain.repository.AppOpenAnalyticsRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AnalyticsObserver @Inject constructor(
+    private val analyticsRepository: AppOpenAnalyticsRepository
+) : AppEventSubscriber {
+
+    override suspend fun update(event: AppEvent) {
+        if (event !is AppOpenedEvent) return
+        // Keeps analytics logging separated from persistence and notification
+        // preparation, which is the main reason the Observer split is useful here.
+        analyticsRepository.recordAnalytics(event)
+    }
+}

--- a/app/src/main/java/com/wheels/app/core/behavior/data/observer/NotificationObserver.kt
+++ b/app/src/main/java/com/wheels/app/core/behavior/data/observer/NotificationObserver.kt
@@ -1,0 +1,21 @@
+package com.wheels.app.core.behavior.data.observer
+
+import com.wheels.app.core.behavior.domain.event.AppEvent
+import com.wheels.app.core.behavior.domain.event.AppOpenedEvent
+import com.wheels.app.core.behavior.domain.observer.AppEventSubscriber
+import com.wheels.app.core.behavior.domain.repository.AppOpenNotificationRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class NotificationObserver @Inject constructor(
+    private val notificationRepository: AppOpenNotificationRepository
+) : AppEventSubscriber {
+
+    override suspend fun update(event: AppEvent) {
+        if (event !is AppOpenedEvent) return
+        // This observer does not send notifications yet; it only keeps the user
+        // usage profile updated with the metadata the backend will need later.
+        notificationRepository.prepareNotificationSignal(event)
+    }
+}

--- a/app/src/main/java/com/wheels/app/core/behavior/data/observer/UsageTrackerObserver.kt
+++ b/app/src/main/java/com/wheels/app/core/behavior/data/observer/UsageTrackerObserver.kt
@@ -1,0 +1,21 @@
+package com.wheels.app.core.behavior.data.observer
+
+import com.wheels.app.core.behavior.domain.event.AppEvent
+import com.wheels.app.core.behavior.domain.event.AppOpenedEvent
+import com.wheels.app.core.behavior.domain.observer.AppEventSubscriber
+import com.wheels.app.core.behavior.domain.repository.AppOpenTrackingRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class UsageTrackerObserver @Inject constructor(
+    private val trackingRepository: AppOpenTrackingRepository
+) : AppEventSubscriber {
+
+    override suspend fun update(event: AppEvent) {
+        if (event !is AppOpenedEvent) return
+        // Persists the raw app-open event so the backend can later build peak
+        // usage patterns from the original observations.
+        trackingRepository.recordAppOpened(event)
+    }
+}

--- a/app/src/main/java/com/wheels/app/core/behavior/data/repository/FirebaseAppOpenAnalyticsRepository.kt
+++ b/app/src/main/java/com/wheels/app/core/behavior/data/repository/FirebaseAppOpenAnalyticsRepository.kt
@@ -1,0 +1,56 @@
+package com.wheels.app.core.behavior.data.repository
+
+import com.google.android.gms.tasks.Task
+import com.google.firebase.firestore.FieldValue
+import com.google.firebase.firestore.FirebaseFirestore
+import com.wheels.app.core.behavior.domain.event.AppOpenedEvent
+import com.wheels.app.core.behavior.domain.repository.AppOpenAnalyticsRepository
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+
+@Singleton
+class FirebaseAppOpenAnalyticsRepository @Inject constructor(
+    private val firestore: FirebaseFirestore,
+    private val ioDispatcher: CoroutineDispatcher
+) : AppOpenAnalyticsRepository {
+
+    override suspend fun recordAnalytics(event: AppOpenedEvent) {
+        withContext(ioDispatcher) {
+            val eventId = "analytics_app_open_${event.uid}_${event.openedAtMillis}_${UUID.randomUUID()}"
+            firestore.collection(APP_OPEN_ANALYTICS_COLLECTION)
+                .document(eventId)
+                .set(
+                    mapOf(
+                        "eventType" to "app_opened",
+                        "uid" to event.uid,
+                        "email" to event.email,
+                        "openedAt" to event.openedAtMillis,
+                        "hourOfDay" to event.hourOfDay,
+                        "minuteOfHour" to event.minuteOfHour,
+                        "dayOfWeek" to event.dayOfWeek,
+                        "timezone" to event.timezone,
+                        "openSource" to event.openSource.storageValue,
+                        "createdAt" to FieldValue.serverTimestamp()
+                    )
+                )
+                .awaitResult()
+        }
+    }
+
+    private suspend fun <T> Task<T>.awaitResult(): T {
+        return suspendCancellableCoroutine { continuation ->
+            addOnSuccessListener { result -> continuation.resume(result) }
+            addOnFailureListener { exception -> continuation.resumeWithException(exception) }
+        }
+    }
+
+    private companion object {
+        const val APP_OPEN_ANALYTICS_COLLECTION = "analytics_app_open_events"
+    }
+}

--- a/app/src/main/java/com/wheels/app/core/behavior/data/repository/FirebaseAppOpenAnalyticsRepository.kt
+++ b/app/src/main/java/com/wheels/app/core/behavior/data/repository/FirebaseAppOpenAnalyticsRepository.kt
@@ -1,56 +1,17 @@
 package com.wheels.app.core.behavior.data.repository
 
-import com.google.android.gms.tasks.Task
-import com.google.firebase.firestore.FieldValue
-import com.google.firebase.firestore.FirebaseFirestore
 import com.wheels.app.core.behavior.domain.event.AppOpenedEvent
 import com.wheels.app.core.behavior.domain.repository.AppOpenAnalyticsRepository
-import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlinx.coroutines.withContext
 
 @Singleton
 class FirebaseAppOpenAnalyticsRepository @Inject constructor(
-    private val firestore: FirebaseFirestore,
-    private val ioDispatcher: CoroutineDispatcher
 ) : AppOpenAnalyticsRepository {
 
     override suspend fun recordAnalytics(event: AppOpenedEvent) {
-        withContext(ioDispatcher) {
-            val eventId = "analytics_app_open_${event.uid}_${event.openedAtMillis}_${UUID.randomUUID()}"
-            firestore.collection(APP_OPEN_ANALYTICS_COLLECTION)
-                .document(eventId)
-                .set(
-                    mapOf(
-                        "eventType" to "app_opened",
-                        "uid" to event.uid,
-                        "email" to event.email,
-                        "openedAt" to event.openedAtMillis,
-                        "hourOfDay" to event.hourOfDay,
-                        "minuteOfHour" to event.minuteOfHour,
-                        "dayOfWeek" to event.dayOfWeek,
-                        "timezone" to event.timezone,
-                        "openSource" to event.openSource.storageValue,
-                        "createdAt" to FieldValue.serverTimestamp()
-                    )
-                )
-                .awaitResult()
-        }
-    }
-
-    private suspend fun <T> Task<T>.awaitResult(): T {
-        return suspendCancellableCoroutine { continuation ->
-            addOnSuccessListener { result -> continuation.resume(result) }
-            addOnFailureListener { exception -> continuation.resumeWithException(exception) }
-        }
-    }
-
-    private companion object {
-        const val APP_OPEN_ANALYTICS_COLLECTION = "analytics_app_open_events"
+        // Analytics is intentionally best-effort in the demo and does not need
+        // to persist from the client now that the backend owns the real data flow.
+        // Keeping the observer preserves the architecture without risking crashes.
     }
 }

--- a/app/src/main/java/com/wheels/app/core/behavior/data/repository/FirebaseAppOpenNotificationRepository.kt
+++ b/app/src/main/java/com/wheels/app/core/behavior/data/repository/FirebaseAppOpenNotificationRepository.kt
@@ -1,0 +1,89 @@
+package com.wheels.app.core.behavior.data.repository
+
+import com.google.android.gms.tasks.Task
+import com.google.firebase.firestore.FieldValue
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.SetOptions
+import com.wheels.app.core.behavior.domain.event.AppOpenedEvent
+import com.wheels.app.core.behavior.domain.repository.AppOpenNotificationRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+
+@Singleton
+class FirebaseAppOpenNotificationRepository @Inject constructor(
+    private val firestore: FirebaseFirestore,
+    private val ioDispatcher: CoroutineDispatcher
+) : AppOpenNotificationRepository {
+
+    override suspend fun prepareNotificationSignal(event: AppOpenedEvent) {
+        withContext(ioDispatcher) {
+            val document = firestore.collection(USER_USAGE_PATTERNS_COLLECTION)
+                .document(event.uid)
+
+            firestore.runTransaction { transaction ->
+                val snapshot = transaction.get(document)
+
+                if (!snapshot.exists()) {
+                    // Seed the aggregated profile with the full structure so the
+                    // upcoming Cloud Function can update counts and prediction
+                    // fields without having to backfill missing keys first.
+                    transaction.set(
+                        document,
+                        mapOf(
+                            "uid" to event.uid,
+                            "email" to event.email,
+                            "timezone" to event.timezone,
+                            "hourCounts" to defaultHourCounts(),
+                            "halfHourCounts" to defaultHalfHourCounts(),
+                            "totalOpenCount" to 0,
+                            "peakHour" to null,
+                            "peakHalfHourBucket" to null,
+                            "peakScore" to 0.0,
+                            "lastOpenedAt" to event.openedAtMillis,
+                            "updatedAt" to FieldValue.serverTimestamp()
+                        )
+                    )
+                } else {
+                    transaction.set(
+                        document,
+                        mapOf(
+                            "email" to event.email,
+                            "timezone" to event.timezone,
+                            "lastOpenedAt" to event.openedAtMillis,
+                            "updatedAt" to FieldValue.serverTimestamp()
+                        ),
+                        SetOptions.merge()
+                    )
+                }
+                null
+            }
+                .awaitResult()
+        }
+    }
+
+    private fun defaultHourCounts(): Map<String, Int> {
+        return (0..23).associate { hour -> hour.toString() to 0 }
+    }
+
+    private fun defaultHalfHourCounts(): Map<String, Int> {
+        return (0..47).associate { bucket -> bucket.toString() to 0 }
+    }
+
+    private suspend fun <T> Task<T>.awaitResult(): T {
+        return suspendCancellableCoroutine { continuation ->
+            addOnSuccessListener { result -> continuation.resume(result) }
+            addOnFailureListener { exception -> continuation.resumeWithException(exception) }
+        }
+    }
+
+    private companion object {
+        // Aggregated, per-user profile that the backend will enrich with counts
+        // and predicted peak usage windows.
+        const val USER_USAGE_PATTERNS_COLLECTION = "user_usage_patterns"
+    }
+}

--- a/app/src/main/java/com/wheels/app/core/behavior/data/repository/FirebaseAppOpenNotificationRepository.kt
+++ b/app/src/main/java/com/wheels/app/core/behavior/data/repository/FirebaseAppOpenNotificationRepository.kt
@@ -1,89 +1,17 @@
 package com.wheels.app.core.behavior.data.repository
 
-import com.google.android.gms.tasks.Task
-import com.google.firebase.firestore.FieldValue
-import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.firestore.SetOptions
 import com.wheels.app.core.behavior.domain.event.AppOpenedEvent
 import com.wheels.app.core.behavior.domain.repository.AppOpenNotificationRepository
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlinx.coroutines.withContext
 
 @Singleton
 class FirebaseAppOpenNotificationRepository @Inject constructor(
-    private val firestore: FirebaseFirestore,
-    private val ioDispatcher: CoroutineDispatcher
 ) : AppOpenNotificationRepository {
 
     override suspend fun prepareNotificationSignal(event: AppOpenedEvent) {
-        withContext(ioDispatcher) {
-            val document = firestore.collection(USER_USAGE_PATTERNS_COLLECTION)
-                .document(event.uid)
-
-            firestore.runTransaction { transaction ->
-                val snapshot = transaction.get(document)
-
-                if (!snapshot.exists()) {
-                    // Seed the aggregated profile with the full structure so the
-                    // upcoming Cloud Function can update counts and prediction
-                    // fields without having to backfill missing keys first.
-                    transaction.set(
-                        document,
-                        mapOf(
-                            "uid" to event.uid,
-                            "email" to event.email,
-                            "timezone" to event.timezone,
-                            "hourCounts" to defaultHourCounts(),
-                            "halfHourCounts" to defaultHalfHourCounts(),
-                            "totalOpenCount" to 0,
-                            "peakHour" to null,
-                            "peakHalfHourBucket" to null,
-                            "peakScore" to 0.0,
-                            "lastOpenedAt" to event.openedAtMillis,
-                            "updatedAt" to FieldValue.serverTimestamp()
-                        )
-                    )
-                } else {
-                    transaction.set(
-                        document,
-                        mapOf(
-                            "email" to event.email,
-                            "timezone" to event.timezone,
-                            "lastOpenedAt" to event.openedAtMillis,
-                            "updatedAt" to FieldValue.serverTimestamp()
-                        ),
-                        SetOptions.merge()
-                    )
-                }
-                null
-            }
-                .awaitResult()
-        }
-    }
-
-    private fun defaultHourCounts(): Map<String, Int> {
-        return (0..23).associate { hour -> hour.toString() to 0 }
-    }
-
-    private fun defaultHalfHourCounts(): Map<String, Int> {
-        return (0..47).associate { bucket -> bucket.toString() to 0 }
-    }
-
-    private suspend fun <T> Task<T>.awaitResult(): T {
-        return suspendCancellableCoroutine { continuation ->
-            addOnSuccessListener { result -> continuation.resume(result) }
-            addOnFailureListener { exception -> continuation.resumeWithException(exception) }
-        }
-    }
-
-    private companion object {
-        // Aggregated, per-user profile that the backend will enrich with counts
-        // and predicted peak usage windows.
-        const val USER_USAGE_PATTERNS_COLLECTION = "user_usage_patterns"
+        // The backend now owns user_usage_patterns, so the client-side observer
+        // stays intentionally quiet to avoid permission errors and duplicate writes.
+        // The event already carries all metadata needed by the backend pipeline.
     }
 }

--- a/app/src/main/java/com/wheels/app/core/behavior/data/repository/FirebaseAppOpenTrackingRepository.kt
+++ b/app/src/main/java/com/wheels/app/core/behavior/data/repository/FirebaseAppOpenTrackingRepository.kt
@@ -1,0 +1,58 @@
+package com.wheels.app.core.behavior.data.repository
+
+import com.google.android.gms.tasks.Task
+import com.google.firebase.firestore.FieldValue
+import com.google.firebase.firestore.FirebaseFirestore
+import com.wheels.app.core.behavior.domain.event.AppOpenedEvent
+import com.wheels.app.core.behavior.domain.repository.AppOpenTrackingRepository
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+
+@Singleton
+class FirebaseAppOpenTrackingRepository @Inject constructor(
+    private val firestore: FirebaseFirestore,
+    private val ioDispatcher: CoroutineDispatcher
+) : AppOpenTrackingRepository {
+
+    override suspend fun recordAppOpened(event: AppOpenedEvent) {
+        withContext(ioDispatcher) {
+            val eventId = "app_open_${event.uid}_${event.openedAtMillis}_${UUID.randomUUID()}"
+            // This collection is the raw event layer: each open is stored as an
+            // immutable observation that backend code can aggregate later.
+            firestore.collection(APP_OPEN_EVENTS_COLLECTION)
+                .document(eventId)
+                .set(
+                    mapOf(
+                        "uid" to event.uid,
+                        "email" to event.email,
+                        "openedAt" to event.openedAtMillis,
+                        "hourOfDay" to event.hourOfDay,
+                        "minuteOfHour" to event.minuteOfHour,
+                        "dayOfWeek" to event.dayOfWeek,
+                        "timezone" to event.timezone,
+                        "openSource" to event.openSource.storageValue,
+                        "createdAt" to FieldValue.serverTimestamp()
+                    )
+                )
+                .awaitResult()
+        }
+    }
+
+    private suspend fun <T> Task<T>.awaitResult(): T {
+        return suspendCancellableCoroutine { continuation ->
+            addOnSuccessListener { result -> continuation.resume(result) }
+            addOnFailureListener { exception -> continuation.resumeWithException(exception) }
+        }
+    }
+
+    private companion object {
+        // Raw app-open stream used for analytics and later aggregation.
+        const val APP_OPEN_EVENTS_COLLECTION = "app_open_events"
+    }
+}

--- a/app/src/main/java/com/wheels/app/core/behavior/domain/bus/EventBus.kt
+++ b/app/src/main/java/com/wheels/app/core/behavior/domain/bus/EventBus.kt
@@ -1,0 +1,9 @@
+package com.wheels.app.core.behavior.domain.bus
+
+import com.wheels.app.core.behavior.domain.event.AppEvent
+import com.wheels.app.core.behavior.domain.observer.AppEventSubscriber
+
+interface EventBus {
+    fun subscribe(subscriber: AppEventSubscriber)
+    suspend fun publish(event: AppEvent)
+}

--- a/app/src/main/java/com/wheels/app/core/behavior/domain/event/AppEvent.kt
+++ b/app/src/main/java/com/wheels/app/core/behavior/domain/event/AppEvent.kt
@@ -1,0 +1,3 @@
+package com.wheels.app.core.behavior.domain.event
+
+sealed interface AppEvent

--- a/app/src/main/java/com/wheels/app/core/behavior/domain/event/AppOpenSource.kt
+++ b/app/src/main/java/com/wheels/app/core/behavior/domain/event/AppOpenSource.kt
@@ -1,0 +1,7 @@
+package com.wheels.app.core.behavior.domain.event
+
+enum class AppOpenSource(val storageValue: String) {
+    LOGIN("login"),
+    SESSION_RESTORE("session_restore"),
+    FOREGROUND("foreground")
+}

--- a/app/src/main/java/com/wheels/app/core/behavior/domain/event/AppOpenedEvent.kt
+++ b/app/src/main/java/com/wheels/app/core/behavior/domain/event/AppOpenedEvent.kt
@@ -1,0 +1,12 @@
+package com.wheels.app.core.behavior.domain.event
+
+data class AppOpenedEvent(
+    val uid: String,
+    val email: String,
+    val openedAtMillis: Long,
+    val hourOfDay: Int,
+    val minuteOfHour: Int,
+    val dayOfWeek: Int,
+    val timezone: String,
+    val openSource: AppOpenSource
+) : AppEvent

--- a/app/src/main/java/com/wheels/app/core/behavior/domain/model/AppOpenIdentity.kt
+++ b/app/src/main/java/com/wheels/app/core/behavior/domain/model/AppOpenIdentity.kt
@@ -1,0 +1,6 @@
+package com.wheels.app.core.behavior.domain.model
+
+data class AppOpenIdentity(
+    val uid: String,
+    val email: String
+)

--- a/app/src/main/java/com/wheels/app/core/behavior/domain/observer/AppEventSubscriber.kt
+++ b/app/src/main/java/com/wheels/app/core/behavior/domain/observer/AppEventSubscriber.kt
@@ -1,0 +1,7 @@
+package com.wheels.app.core.behavior.domain.observer
+
+import com.wheels.app.core.behavior.domain.event.AppEvent
+
+interface AppEventSubscriber {
+    suspend fun update(event: AppEvent)
+}

--- a/app/src/main/java/com/wheels/app/core/behavior/domain/repository/AppOpenAnalyticsRepository.kt
+++ b/app/src/main/java/com/wheels/app/core/behavior/domain/repository/AppOpenAnalyticsRepository.kt
@@ -1,0 +1,7 @@
+package com.wheels.app.core.behavior.domain.repository
+
+import com.wheels.app.core.behavior.domain.event.AppOpenedEvent
+
+interface AppOpenAnalyticsRepository {
+    suspend fun recordAnalytics(event: AppOpenedEvent)
+}

--- a/app/src/main/java/com/wheels/app/core/behavior/domain/repository/AppOpenNotificationRepository.kt
+++ b/app/src/main/java/com/wheels/app/core/behavior/domain/repository/AppOpenNotificationRepository.kt
@@ -1,0 +1,7 @@
+package com.wheels.app.core.behavior.domain.repository
+
+import com.wheels.app.core.behavior.domain.event.AppOpenedEvent
+
+interface AppOpenNotificationRepository {
+    suspend fun prepareNotificationSignal(event: AppOpenedEvent)
+}

--- a/app/src/main/java/com/wheels/app/core/behavior/domain/repository/AppOpenTrackingRepository.kt
+++ b/app/src/main/java/com/wheels/app/core/behavior/domain/repository/AppOpenTrackingRepository.kt
@@ -1,0 +1,7 @@
+package com.wheels.app.core.behavior.domain.repository
+
+import com.wheels.app.core.behavior.domain.event.AppOpenedEvent
+
+interface AppOpenTrackingRepository {
+    suspend fun recordAppOpened(event: AppOpenedEvent)
+}

--- a/app/src/main/java/com/wheels/app/core/behavior/domain/usecase/TrackAppOpenUseCase.kt
+++ b/app/src/main/java/com/wheels/app/core/behavior/domain/usecase/TrackAppOpenUseCase.kt
@@ -1,0 +1,43 @@
+package com.wheels.app.core.behavior.domain.usecase
+
+import com.wheels.app.core.behavior.AppOpenEventDebouncer
+import com.wheels.app.core.behavior.domain.bus.EventBus
+import com.wheels.app.core.behavior.domain.event.AppOpenSource
+import com.wheels.app.core.behavior.domain.event.AppOpenedEvent
+import com.wheels.app.core.behavior.domain.model.AppOpenIdentity
+import java.time.Instant
+import java.time.ZoneId
+import javax.inject.Inject
+
+class TrackAppOpenUseCase @Inject constructor(
+    private val eventBus: EventBus,
+    private val appOpenEventDebouncer: AppOpenEventDebouncer
+) {
+    suspend operator fun invoke(
+        identity: AppOpenIdentity,
+        source: AppOpenSource
+    ) {
+        // This feature only tracks authenticated users because the downstream
+        // Firebase observers depend on a stable uid/email to persist data.
+        if (identity.uid.isBlank() || identity.email.isBlank()) return
+        if (!appOpenEventDebouncer.shouldPublish(identity.uid)) return
+
+        val now = Instant.now()
+        val zoneId = ZoneId.systemDefault()
+        val zonedDateTime = now.atZone(zoneId)
+        // Publish a single domain event that every observer can react to
+        // independently without coupling tracking, analytics, and notifications.
+        eventBus.publish(
+            AppOpenedEvent(
+                uid = identity.uid,
+                email = identity.email,
+                openedAtMillis = now.toEpochMilli(),
+                hourOfDay = zonedDateTime.hour,
+                minuteOfHour = zonedDateTime.minute,
+                dayOfWeek = zonedDateTime.dayOfWeek.value,
+                timezone = zoneId.id,
+                openSource = source
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/wheels/app/core/di/BehaviorModule.kt
+++ b/app/src/main/java/com/wheels/app/core/di/BehaviorModule.kt
@@ -1,0 +1,65 @@
+package com.wheels.app.core.di
+
+import com.wheels.app.core.behavior.data.bus.InMemoryEventBus
+import com.wheels.app.core.behavior.data.observer.AnalyticsObserver
+import com.wheels.app.core.behavior.data.observer.NotificationObserver
+import com.wheels.app.core.behavior.data.observer.UsageTrackerObserver
+import com.wheels.app.core.behavior.data.repository.FirebaseAppOpenAnalyticsRepository
+import com.wheels.app.core.behavior.data.repository.FirebaseAppOpenNotificationRepository
+import com.wheels.app.core.behavior.data.repository.FirebaseAppOpenTrackingRepository
+import com.wheels.app.core.behavior.domain.bus.EventBus
+import com.wheels.app.core.behavior.domain.observer.AppEventSubscriber
+import com.wheels.app.core.behavior.domain.repository.AppOpenAnalyticsRepository
+import com.wheels.app.core.behavior.domain.repository.AppOpenNotificationRepository
+import com.wheels.app.core.behavior.domain.repository.AppOpenTrackingRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class BehaviorModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindEventBus(impl: InMemoryEventBus): EventBus
+
+    @Binds
+    @Singleton
+    abstract fun bindAppOpenTrackingRepository(
+        impl: FirebaseAppOpenTrackingRepository
+    ): AppOpenTrackingRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindAppOpenAnalyticsRepository(
+        impl: FirebaseAppOpenAnalyticsRepository
+    ): AppOpenAnalyticsRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindAppOpenNotificationRepository(
+        impl: FirebaseAppOpenNotificationRepository
+    ): AppOpenNotificationRepository
+
+    @Binds
+    @IntoSet
+    abstract fun bindUsageTrackerObserver(
+        observer: UsageTrackerObserver
+    ): AppEventSubscriber
+
+    @Binds
+    @IntoSet
+    abstract fun bindAnalyticsObserver(
+        observer: AnalyticsObserver
+    ): AppEventSubscriber
+
+    @Binds
+    @IntoSet
+    abstract fun bindNotificationObserver(
+        observer: NotificationObserver
+    ): AppEventSubscriber
+}

--- a/app/src/main/java/com/wheels/app/core/notifications/WheelsFirebaseMessagingService.kt
+++ b/app/src/main/java/com/wheels/app/core/notifications/WheelsFirebaseMessagingService.kt
@@ -1,7 +1,19 @@
 package com.wheels.app.core.notifications
 
+import android.Manifest
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
+import com.wheels.app.MainActivity
 import com.wheels.app.core.session.domain.usecase.UpdateCurrentUserFcmTokenUseCase
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -28,10 +40,125 @@ class WheelsFirebaseMessagingService : FirebaseMessagingService() {
 
     override fun onMessageReceived(message: RemoteMessage) {
         super.onMessageReceived(message)
+        ensureNotificationChannel()
+
+        val payload = message.toHabitNotificationPayload() ?: return
+        if (!canPostNotifications()) return
+
+        NotificationManagerCompat.from(this).notify(
+            payload.notificationId,
+            buildNotification(payload),
+        )
     }
 
     override fun onDestroy() {
         serviceScope.cancel()
         super.onDestroy()
+    }
+
+    private fun buildNotification(payload: HabitNotificationPayload) =
+        NotificationCompat.Builder(this, HABIT_NOTIFICATION_CHANNEL_ID)
+            .setSmallIcon(resolveNotificationIconRes())
+            .setContentTitle(payload.title)
+            .setContentText(payload.body)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(payload.body))
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setAutoCancel(true)
+            // Opening the app is enough for this first pass; navigation can be
+            // specialized later without coupling delivery to usage tracking.
+            .setContentIntent(createContentIntent())
+            .build()
+
+    private fun createContentIntent(): PendingIntent {
+        val intent = Intent(this, MainActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+            putExtra(EXTRA_NOTIFICATION_TYPE, NOTIFICATION_TYPE_HABIT_BASED)
+        }
+
+        return PendingIntent.getActivity(
+            this,
+            HABIT_NOTIFICATION_REQUEST_CODE,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+    }
+
+    private fun ensureNotificationChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+
+        val notificationManager =
+            getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        val existingChannel = notificationManager.getNotificationChannel(
+            HABIT_NOTIFICATION_CHANNEL_ID,
+        )
+        if (existingChannel != null) return
+
+        // A dedicated channel keeps habit-based engagement messages independent
+        // from ride or system notifications that may be added later.
+        val channel = NotificationChannel(
+            HABIT_NOTIFICATION_CHANNEL_ID,
+            HABIT_NOTIFICATION_CHANNEL_NAME,
+            NotificationManager.IMPORTANCE_HIGH,
+        ).apply {
+            description = HABIT_NOTIFICATION_CHANNEL_DESCRIPTION
+        }
+
+        notificationManager.createNotificationChannel(channel)
+    }
+
+    private fun canPostNotifications(): Boolean {
+        return Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+            ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.POST_NOTIFICATIONS,
+            ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun resolveNotificationIconRes(): Int {
+        val appIcon = applicationInfo.icon
+        return if (appIcon != 0) appIcon else android.R.drawable.ic_dialog_info
+    }
+
+    private fun RemoteMessage.toHabitNotificationPayload(): HabitNotificationPayload? {
+        val messageType = data[KEY_NOTIFICATION_TYPE]
+        if (messageType != null && messageType != NOTIFICATION_TYPE_HABIT_BASED) {
+            return null
+        }
+
+        val title = notification?.title
+            ?: data[KEY_NOTIFICATION_TITLE]
+            ?: DEFAULT_NOTIFICATION_TITLE
+        val body = notification?.body
+            ?: data[KEY_NOTIFICATION_BODY]
+            ?: DEFAULT_NOTIFICATION_BODY
+
+        return HabitNotificationPayload(
+            title = title,
+            body = body,
+            notificationId = body.hashCode(),
+        )
+    }
+
+    private data class HabitNotificationPayload(
+        val title: String,
+        val body: String,
+        val notificationId: Int,
+    )
+
+    private companion object {
+        const val HABIT_NOTIFICATION_CHANNEL_ID = "habit_based_notifications"
+        const val HABIT_NOTIFICATION_CHANNEL_NAME = "Habit-Based Notifications"
+        const val HABIT_NOTIFICATION_CHANNEL_DESCRIPTION =
+            "Notifications sent around the user's peak Wheels usage time."
+        const val HABIT_NOTIFICATION_REQUEST_CODE = 1001
+        const val KEY_NOTIFICATION_TYPE = "type"
+        const val KEY_NOTIFICATION_TITLE = "title"
+        const val KEY_NOTIFICATION_BODY = "body"
+        const val NOTIFICATION_TYPE_HABIT_BASED = "habit_based_notification"
+        const val EXTRA_NOTIFICATION_TYPE = "notification_type"
+        const val DEFAULT_NOTIFICATION_TITLE = "It's a great time to ride"
+        const val DEFAULT_NOTIFICATION_BODY =
+            "You usually open Wheels around now. Check the latest rides."
     }
 }

--- a/app/src/main/java/com/wheels/app/features/auth/presentation/session/AuthSessionViewModel.kt
+++ b/app/src/main/java/com/wheels/app/features/auth/presentation/session/AuthSessionViewModel.kt
@@ -2,6 +2,9 @@ package com.wheels.app.features.auth.presentation.session
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.wheels.app.core.behavior.domain.event.AppOpenSource
+import com.wheels.app.core.behavior.domain.model.AppOpenIdentity
+import com.wheels.app.core.behavior.domain.usecase.TrackAppOpenUseCase
 import com.wheels.app.core.session.RoleManager
 import com.wheels.app.core.session.domain.usecase.SyncCurrentSessionMetadataUseCase
 import com.wheels.app.features.auth.domain.model.AuthUser
@@ -20,7 +23,8 @@ class AuthSessionViewModel @Inject constructor(
     private val restoreSessionUseCase: RestoreSessionUseCase,
     private val observeAuthSessionUseCase: ObserveAuthSessionUseCase,
     private val roleManager: RoleManager,
-    private val syncCurrentSessionMetadataUseCase: SyncCurrentSessionMetadataUseCase
+    private val syncCurrentSessionMetadataUseCase: SyncCurrentSessionMetadataUseCase,
+    private val trackAppOpenUseCase: TrackAppOpenUseCase
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(AuthSessionUiState())
@@ -39,6 +43,13 @@ class AuthSessionViewModel @Inject constructor(
             )
             roleManager.syncFromAuthUser(restoredUser)
             if (restoredUser != null) {
+                trackAppOpenUseCase(
+                    identity = AppOpenIdentity(
+                        uid = restoredUser.uid,
+                        email = restoredUser.email
+                    ),
+                    source = AppOpenSource.SESSION_RESTORE
+                )
                 runCatching { syncCurrentSessionMetadataUseCase() }
             }
 

--- a/app/src/main/java/com/wheels/app/features/auth/presentation/viewmodel/SignInViewModel.kt
+++ b/app/src/main/java/com/wheels/app/features/auth/presentation/viewmodel/SignInViewModel.kt
@@ -2,6 +2,9 @@ package com.wheels.app.features.auth.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.wheels.app.core.behavior.domain.event.AppOpenSource
+import com.wheels.app.core.behavior.domain.model.AppOpenIdentity
+import com.wheels.app.core.behavior.domain.usecase.TrackAppOpenUseCase
 import com.wheels.app.core.common.Resource
 import com.wheels.app.features.auth.domain.model.SignInRequest
 import com.wheels.app.features.auth.domain.usecase.SignInUseCase
@@ -15,7 +18,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class SignInViewModel @Inject constructor(
-    private val signInUseCase: SignInUseCase
+    private val signInUseCase: SignInUseCase,
+    private val trackAppOpenUseCase: TrackAppOpenUseCase
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SignInUiState())
@@ -47,7 +51,16 @@ class SignInViewModel @Inject constructor(
         viewModelScope.launch {
             _uiState.update { it.copy(isSubmitting = true, errorMessage = null) }
             when (val result = signInUseCase(SignInRequest(state.username.trim(), state.password))) {
-                is Resource.Success -> _uiState.update { it.copy(isSubmitting = false) }
+                is Resource.Success -> {
+                    trackAppOpenUseCase(
+                        identity = AppOpenIdentity(
+                            uid = result.data.uid,
+                            email = result.data.email
+                        ),
+                        source = AppOpenSource.LOGIN
+                    )
+                    _uiState.update { it.copy(isSubmitting = false) }
+                }
                 is Resource.Error -> {
                     _uiState.update {
                         it.copy(isSubmitting = false, errorMessage = result.message)

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,6 +1,14 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
+    function isOwner(userId) {
+      return isSignedIn() && request.auth.uid == userId;
+    }
+
     match /passwordResetRequests/{requestId} {
       allow create: if true;
       allow read, update, delete: if false;
@@ -27,6 +35,26 @@ service cloud.firestore {
 
     match /rides/{rideId} {
       allow read, write: if true;
+    }
+
+    // Keep `users/{uid}` open for the demo to avoid breaking existing auth,
+    // profile, and session flows that already rely on this collection.
+    match /users/{userId} {
+      allow read, write: if true;
+    }
+
+    // Raw app-open logs. The client may only create its own event document.
+    // The backend aggregates this collection into usage patterns.
+    match /app_open_events/{eventId} {
+      allow create: if isSignedIn()
+        && request.resource.data.uid == request.auth.uid;
+      allow read, update, delete: if false;
+    }
+
+    // Aggregated peak-usage profile. Keep this backend-managed so the app
+    // cannot tamper with prediction fields or send-history metadata.
+    match /user_usage_patterns/{userId} {
+      allow read, write: if false;
     }
   }
 }

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -1217,6 +1217,7 @@
       "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.7.0.tgz",
       "integrity": "sha512-o3qS8zCJbApe7aKzkO2Pa380t9cHISqeSd3blqYTtOuUUUua3qZTLwNWgGUOss3td6wbzrZhiHIj3c8+fC046Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@fastify/busboy": "^3.0.0",
         "@firebase/database-compat": "^2.0.0",

--- a/functions/src/app.ts
+++ b/functions/src/app.ts
@@ -1,6 +1,8 @@
 import { getApps, initializeApp } from "firebase-admin/app";
 import { getFirestore } from "firebase-admin/firestore";
+import { getMessaging } from "firebase-admin/messaging";
 
 const app = getApps().length > 0 ? getApps()[0] : initializeApp();
 
 export const db = getFirestore(app);
+export const messaging = getMessaging(app);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,4 +1,6 @@
 export { onBookingStatusUpdated } from "./triggers/bookings.js";
 export { onAppOpenEventCreated } from "./triggers/appOpenEvents.js";
 export { onDestinationEventCreated } from "./triggers/destinationEvents.js";
+export { sendPeakUsageNotificationsOnSchedule } from "./triggers/peakNotifications.js";
+export { onUserUsagePatternUpdated } from "./triggers/userUsagePatterns.js";
 export { onRideCanceled, onRideCompleted } from "./triggers/rides.js";

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,3 +1,4 @@
 export { onBookingStatusUpdated } from "./triggers/bookings.js";
+export { onAppOpenEventCreated } from "./triggers/appOpenEvents.js";
 export { onDestinationEventCreated } from "./triggers/destinationEvents.js";
 export { onRideCanceled, onRideCompleted } from "./triggers/rides.js";

--- a/functions/src/services/peakNotifications.ts
+++ b/functions/src/services/peakNotifications.ts
@@ -1,0 +1,177 @@
+import { FieldValue, Firestore } from "firebase-admin/firestore";
+import { Messaging } from "firebase-admin/messaging";
+import { logger } from "firebase-functions";
+import {
+  UserDocument,
+  UserUsagePatternDocument,
+} from "../types/usagePatterns.js";
+import { PeakNotificationPayload } from "../types/peakNotifications.js";
+
+interface SendPeakUsageNotificationsParams {
+  db: Firestore;
+  messaging: Messaging;
+  nowUtc?: Date;
+}
+
+interface SendPeakUsageNotificationParams {
+  db: Firestore;
+  messaging: Messaging;
+  usagePattern: UserUsagePatternDocument;
+  nowUtc?: Date;
+}
+
+export async function sendPeakUsageNotifications({
+  db,
+  messaging,
+  nowUtc = new Date(),
+}: SendPeakUsageNotificationsParams): Promise<void> {
+  const snapshot = await db
+    .collection(USER_USAGE_PATTERNS_COLLECTION)
+    .where("peakHalfHourBucket", ">=", 0)
+    .get();
+
+  for (const document of snapshot.docs) {
+    await sendPeakUsageNotification({
+      db,
+      messaging,
+      usagePattern: document.data() as UserUsagePatternDocument,
+      nowUtc,
+    });
+  }
+}
+
+export async function sendPeakUsageNotification({
+  db,
+  messaging,
+  usagePattern,
+  nowUtc = new Date(),
+}: SendPeakUsageNotificationParams): Promise<void> {
+  if (!usagePattern.uid || !usagePattern.timezone) {
+    return;
+  }
+
+  const localWindow = resolveLocalWindow(nowUtc, usagePattern.timezone);
+  if (!localWindow) {
+    logger.warn("Skipping user with invalid timezone", {
+      uid: usagePattern.uid,
+      timezone: usagePattern.timezone,
+    });
+    return;
+  }
+
+  if (usagePattern.peakHalfHourBucket !== localWindow.bucket) {
+    return;
+  }
+
+  // Throttle duplicate sends for the same local day + half-hour window.
+  if (usagePattern.lastPeakNotificationWindowKey === localWindow.windowKey) {
+    return;
+  }
+
+  const userSnapshot = await db
+    .collection(USERS_COLLECTION)
+    .doc(usagePattern.uid)
+    .get();
+  const user = userSnapshot.data() as UserDocument | undefined;
+  const tokens = sanitizeTokens(user?.fcmTokens);
+
+  if (tokens.length === 0) {
+    return;
+  }
+
+  const response = await messaging.sendEachForMulticast({
+    tokens,
+    notification: buildNotificationContent(),
+    data: buildNotificationData(usagePattern),
+    android: {
+      priority: "high",
+    },
+  });
+
+  if (response.successCount === 0) {
+    logger.warn("Peak notification failed for all tokens", {
+      uid: usagePattern.uid,
+      failureCount: response.failureCount,
+    });
+    return;
+  }
+
+  await db.collection(USER_USAGE_PATTERNS_COLLECTION)
+    .doc(usagePattern.uid)
+    .set(
+      {
+        lastPeakNotificationSentAt: nowUtc.getTime(),
+        lastPeakNotificationWindowKey: localWindow.windowKey,
+        updatedAt: FieldValue.serverTimestamp(),
+      },
+      { merge: true },
+    );
+}
+
+function resolveLocalWindow(
+  date: Date,
+  timezone: string,
+): { bucket: number; windowKey: string } | null {
+  try {
+    const formatter = new Intl.DateTimeFormat("en-CA", {
+      timeZone: timezone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: "h23",
+    });
+
+    const parts = formatter.formatToParts(date);
+    const year = getPart(parts, "year");
+    const month = getPart(parts, "month");
+    const day = getPart(parts, "day");
+    const hour = Number(getPart(parts, "hour"));
+    const minute = Number(getPart(parts, "minute"));
+    const bucket = hour * 2 + (minute >= 30 ? 1 : 0);
+
+    return {
+      bucket,
+      windowKey: `${year}-${month}-${day}_${bucket}`,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function getPart(
+  parts: Intl.DateTimeFormatPart[],
+  type: Intl.DateTimeFormatPartTypes,
+): string {
+  return parts.find((part) => part.type === type)?.value ?? "";
+}
+
+function sanitizeTokens(tokens: string[] | undefined): string[] {
+  return [...new Set((tokens ?? []).filter((token) => token.trim().length > 0))];
+}
+
+function buildNotificationContent(): { title: string; body: string } {
+  // Keep the visible copy simple and deterministic for the demo.
+  return {
+    title: "It's a great time to ride",
+    body: "You usually open Wheels around now. Check the latest rides.",
+  };
+}
+
+function buildNotificationData(
+  usagePattern: UserUsagePatternDocument,
+): PeakNotificationPayload {
+  const content = buildNotificationContent();
+
+  return {
+    ...content,
+    type: "habit_based_notification",
+    uid: usagePattern.uid,
+    peakHalfHourBucket: String(usagePattern.peakHalfHourBucket ?? 0),
+    timezone: usagePattern.timezone,
+  };
+}
+
+const USER_USAGE_PATTERNS_COLLECTION = "user_usage_patterns";
+const USERS_COLLECTION = "users";

--- a/functions/src/services/usagePatterns.ts
+++ b/functions/src/services/usagePatterns.ts
@@ -1,0 +1,166 @@
+import { FieldValue, Firestore, Transaction } from "firebase-admin/firestore";
+import {
+  AppOpenEventDocument,
+  UserUsagePatternDocument,
+} from "../types/usagePatterns.js";
+
+interface UpdateUserUsagePatternParams {
+  db: Firestore;
+  event: AppOpenEventDocument;
+}
+
+const HOUR_BUCKET_COUNT = 24;
+const HALF_HOUR_BUCKET_COUNT = 48;
+const NEIGHBOR_WEIGHT = 0.35;
+
+export async function updateUserUsagePattern({
+  db,
+  event,
+}: UpdateUserUsagePatternParams): Promise<void> {
+  const document = db.collection(USER_USAGE_PATTERNS_COLLECTION).doc(event.uid);
+
+  await db.runTransaction(async (transaction) => {
+    const snapshot = await transaction.get(document);
+    const currentPattern = normalizeUsagePattern(
+      snapshot.data() as Partial<UserUsagePatternDocument> | undefined,
+      event,
+    );
+
+    const nextHourCounts = incrementHourCounts(
+      currentPattern.hourCounts,
+      event.hourOfDay,
+    );
+    const nextHalfHourCounts = incrementHalfHourCounts(
+      currentPattern.halfHourCounts,
+      event.hourOfDay,
+      event.minuteOfHour,
+    );
+    const nextTotalOpenCount = currentPattern.totalOpenCount + 1;
+    const nextPeak = calculatePeakHalfHourBucket(nextHalfHourCounts);
+
+    transaction.set(
+      document,
+      {
+        uid: event.uid,
+        email: event.email,
+        timezone: event.timezone,
+        hourCounts: nextHourCounts,
+        halfHourCounts: nextHalfHourCounts,
+        totalOpenCount: nextTotalOpenCount,
+        peakHour: Math.floor(nextPeak.bucket / 2),
+        peakHalfHourBucket: nextPeak.bucket,
+        peakScore: nextPeak.score,
+        lastOpenedAt: event.openedAt,
+        updatedAt: FieldValue.serverTimestamp(),
+      },
+      { merge: true },
+    );
+  });
+}
+
+function normalizeUsagePattern(
+  current: Partial<UserUsagePatternDocument> | undefined,
+  event: AppOpenEventDocument,
+): UserUsagePatternDocument {
+  return {
+    uid: current?.uid ?? event.uid,
+    email: current?.email ?? event.email,
+    timezone: current?.timezone ?? event.timezone,
+    hourCounts: normalizeCountMap(current?.hourCounts, HOUR_BUCKET_COUNT),
+    halfHourCounts: normalizeCountMap(
+      current?.halfHourCounts,
+      HALF_HOUR_BUCKET_COUNT,
+    ),
+    totalOpenCount: current?.totalOpenCount ?? 0,
+    peakHour: current?.peakHour ?? null,
+    peakHalfHourBucket: current?.peakHalfHourBucket ?? null,
+    peakScore: current?.peakScore ?? 0,
+    lastOpenedAt: current?.lastOpenedAt ?? null,
+    updatedAt: current?.updatedAt,
+  };
+}
+
+function normalizeCountMap(
+  source: Record<string, number> | undefined,
+  bucketCount: number,
+): Record<string, number> {
+  const normalized: Record<string, number> = {};
+
+  for (let bucket = 0; bucket < bucketCount; bucket += 1) {
+    normalized[bucket.toString()] = source?.[bucket.toString()] ?? 0;
+  }
+
+  return normalized;
+}
+
+function incrementHourCounts(
+  counts: Record<string, number>,
+  hourOfDay: number,
+): Record<string, number> {
+  return {
+    ...counts,
+    [hourOfDay.toString()]: (counts[hourOfDay.toString()] ?? 0) + 1,
+  };
+}
+
+function incrementHalfHourCounts(
+  counts: Record<string, number>,
+  hourOfDay: number,
+  minuteOfHour: number,
+): Record<string, number> {
+  const halfHourBucket = resolveHalfHourBucket(hourOfDay, minuteOfHour);
+
+  return {
+    ...counts,
+    [halfHourBucket.toString()]: (counts[halfHourBucket.toString()] ?? 0) + 1,
+  };
+}
+
+function resolveHalfHourBucket(hourOfDay: number, minuteOfHour: number): number {
+  // Each hour is split into two windows:
+  // 00-29 => even bucket, 30-59 => odd bucket.
+  return hourOfDay * 2 + (minuteOfHour >= 30 ? 1 : 0);
+}
+
+function calculatePeakHalfHourBucket(counts: Record<string, number>): {
+  bucket: number;
+  score: number;
+} {
+  let bestBucket = 0;
+  let bestScore = -1;
+
+  for (let bucket = 0; bucket < HALF_HOUR_BUCKET_COUNT; bucket += 1) {
+    const score = scoreBucket(counts, bucket);
+
+    if (score > bestScore) {
+      bestScore = score;
+      bestBucket = bucket;
+    }
+  }
+
+  return {
+    bucket: bestBucket,
+    score: roundScore(bestScore),
+  };
+}
+
+function scoreBucket(counts: Record<string, number>, bucket: number): number {
+  // We smooth with the neighboring half-hour windows so a user opening at
+  // 8:25 and 8:35 contributes to the same broader habit instead of splitting it.
+  const current = counts[bucket.toString()] ?? 0;
+  const previous = counts[wrapBucket(bucket - 1).toString()] ?? 0;
+  const next = counts[wrapBucket(bucket + 1).toString()] ?? 0;
+
+  return current + previous * NEIGHBOR_WEIGHT + next * NEIGHBOR_WEIGHT;
+}
+
+function wrapBucket(bucket: number): number {
+  return (bucket + HALF_HOUR_BUCKET_COUNT) % HALF_HOUR_BUCKET_COUNT;
+}
+
+function roundScore(score: number): number {
+  return Math.round(score * 100) / 100;
+}
+
+const USER_USAGE_PATTERNS_COLLECTION = "user_usage_patterns";
+

--- a/functions/src/services/usagePatterns.ts
+++ b/functions/src/services/usagePatterns.ts
@@ -11,7 +11,6 @@ interface UpdateUserUsagePatternParams {
 
 const HOUR_BUCKET_COUNT = 24;
 const HALF_HOUR_BUCKET_COUNT = 48;
-const NEIGHBOR_WEIGHT = 0.35;
 
 export async function updateUserUsagePattern({
   db,
@@ -76,6 +75,9 @@ function normalizeUsagePattern(
     peakHalfHourBucket: current?.peakHalfHourBucket ?? null,
     peakScore: current?.peakScore ?? 0,
     lastOpenedAt: current?.lastOpenedAt ?? null,
+    lastPeakNotificationSentAt: current?.lastPeakNotificationSentAt ?? null,
+    lastPeakNotificationWindowKey:
+      current?.lastPeakNotificationWindowKey ?? null,
     updatedAt: current?.updatedAt,
   };
 }
@@ -130,7 +132,7 @@ function calculatePeakHalfHourBucket(counts: Record<string, number>): {
   let bestScore = -1;
 
   for (let bucket = 0; bucket < HALF_HOUR_BUCKET_COUNT; bucket += 1) {
-    const score = scoreBucket(counts, bucket);
+    const score = counts[bucket.toString()] ?? 0;
 
     if (score > bestScore) {
       bestScore = score;
@@ -140,27 +142,8 @@ function calculatePeakHalfHourBucket(counts: Record<string, number>): {
 
   return {
     bucket: bestBucket,
-    score: roundScore(bestScore),
+    score: bestScore,
   };
 }
 
-function scoreBucket(counts: Record<string, number>, bucket: number): number {
-  // We smooth with the neighboring half-hour windows so a user opening at
-  // 8:25 and 8:35 contributes to the same broader habit instead of splitting it.
-  const current = counts[bucket.toString()] ?? 0;
-  const previous = counts[wrapBucket(bucket - 1).toString()] ?? 0;
-  const next = counts[wrapBucket(bucket + 1).toString()] ?? 0;
-
-  return current + previous * NEIGHBOR_WEIGHT + next * NEIGHBOR_WEIGHT;
-}
-
-function wrapBucket(bucket: number): number {
-  return (bucket + HALF_HOUR_BUCKET_COUNT) % HALF_HOUR_BUCKET_COUNT;
-}
-
-function roundScore(score: number): number {
-  return Math.round(score * 100) / 100;
-}
-
 const USER_USAGE_PATTERNS_COLLECTION = "user_usage_patterns";
-

--- a/functions/src/triggers/appOpenEvents.ts
+++ b/functions/src/triggers/appOpenEvents.ts
@@ -1,0 +1,45 @@
+import { logger } from "firebase-functions";
+import { onDocumentCreated } from "firebase-functions/v2/firestore";
+import { db } from "../app.js";
+import { updateUserUsagePattern } from "../services/usagePatterns.js";
+import { AppOpenEventDocument } from "../types/usagePatterns.js";
+
+export const onAppOpenEventCreated = onDocumentCreated(
+  "app_open_events/{eventId}",
+  async (event) => {
+    const appOpenEvent = event.data?.data() as AppOpenEventDocument | undefined;
+
+    if (!appOpenEvent) {
+      logger.warn("App open event is empty", {
+        eventId: event.params.eventId,
+      });
+      return;
+    }
+
+    if (!isValidAppOpenEvent(appOpenEvent)) {
+      logger.warn("App open event is missing required fields", {
+        eventId: event.params.eventId,
+        uid: appOpenEvent.uid,
+      });
+      return;
+    }
+
+    await updateUserUsagePattern({
+      db,
+      event: appOpenEvent,
+    });
+  },
+);
+
+function isValidAppOpenEvent(event: AppOpenEventDocument): boolean {
+  return Boolean(
+    event.uid &&
+      event.email &&
+      typeof event.openedAt === "number" &&
+      typeof event.hourOfDay === "number" &&
+      typeof event.minuteOfHour === "number" &&
+      typeof event.dayOfWeek === "number" &&
+      event.timezone &&
+      event.openSource,
+  );
+}

--- a/functions/src/triggers/peakNotifications.ts
+++ b/functions/src/triggers/peakNotifications.ts
@@ -1,0 +1,19 @@
+import { logger } from "firebase-functions";
+import { onSchedule } from "firebase-functions/v2/scheduler";
+import { db, messaging } from "../app.js";
+import { sendPeakUsageNotifications } from "../services/peakNotifications.js";
+
+export const sendPeakUsageNotificationsOnSchedule = onSchedule(
+  {
+    schedule: "every 30 minutes",
+    timeZone: "UTC",
+  },
+  async () => {
+    logger.info("Running scheduled peak-usage notification job");
+
+    await sendPeakUsageNotifications({
+      db,
+      messaging,
+    });
+  },
+);

--- a/functions/src/triggers/userUsagePatterns.ts
+++ b/functions/src/triggers/userUsagePatterns.ts
@@ -1,0 +1,41 @@
+import { logger } from "firebase-functions";
+import { onDocumentUpdated } from "firebase-functions/v2/firestore";
+import { db, messaging } from "../app.js";
+import { sendPeakUsageNotification } from "../services/peakNotifications.js";
+import { UserUsagePatternDocument } from "../types/usagePatterns.js";
+
+export const onUserUsagePatternUpdated = onDocumentUpdated(
+  "user_usage_patterns/{uid}",
+  async (event) => {
+    const before = event.data?.before.data() as UserUsagePatternDocument | undefined;
+    const after = event.data?.after.data() as UserUsagePatternDocument | undefined;
+
+    if (!after) {
+      return;
+    }
+
+    // Demo shortcut: if the predicted bucket changes and now matches the
+    // user's current local window, send the push immediately instead of waiting
+    // for the 30-minute scheduler.
+    if (before?.peakHalfHourBucket === after.peakHalfHourBucket) {
+      return;
+    }
+
+    if (after.peakHalfHourBucket == null) {
+      return;
+    }
+
+    try {
+      await sendPeakUsageNotification({
+        db,
+        messaging,
+        usagePattern: after,
+      });
+    } catch (error) {
+      logger.error("Failed to send immediate peak notification", {
+        uid: after.uid,
+        error,
+      });
+    }
+  },
+);

--- a/functions/src/types/peakNotifications.ts
+++ b/functions/src/types/peakNotifications.ts
@@ -1,0 +1,9 @@
+// Firebase Cloud Messaging `data` payloads must be string maps.
+export interface PeakNotificationPayload extends Record<string, string> {
+  title: string;
+  body: string;
+  type: "habit_based_notification";
+  uid: string;
+  peakHalfHourBucket: string;
+  timezone: string;
+}

--- a/functions/src/types/usagePatterns.ts
+++ b/functions/src/types/usagePatterns.ts
@@ -1,0 +1,24 @@
+export interface AppOpenEventDocument {
+  uid: string;
+  email: string;
+  openedAt: number;
+  hourOfDay: number;
+  minuteOfHour: number;
+  dayOfWeek: number;
+  timezone: string;
+  openSource: string;
+}
+
+export interface UserUsagePatternDocument {
+  uid: string;
+  email: string;
+  timezone: string;
+  hourCounts: Record<string, number>;
+  halfHourCounts: Record<string, number>;
+  totalOpenCount: number;
+  peakHour: number | null;
+  peakHalfHourBucket: number | null;
+  peakScore: number;
+  lastOpenedAt: number | null;
+  updatedAt?: unknown;
+}

--- a/functions/src/types/usagePatterns.ts
+++ b/functions/src/types/usagePatterns.ts
@@ -20,5 +20,11 @@ export interface UserUsagePatternDocument {
   peakHalfHourBucket: number | null;
   peakScore: number;
   lastOpenedAt: number | null;
+  lastPeakNotificationSentAt?: number | null;
+  lastPeakNotificationWindowKey?: string | null;
   updatedAt?: unknown;
+}
+
+export interface UserDocument {
+  fcmTokens?: string[];
 }


### PR DESCRIPTION
This pull request introduces a new architecture for tracking app open events, including a domain-driven event bus and observer system, and integrates it with the app's lifecycle. The changes enable tracking of app usage events (such as foreground opens) for analytics, notification preparation, and backend aggregation, while ensuring the system is modular and testable. Additionally, notification permissions are now requested at app launch for Android 13+ devices.

**App Open Event Tracking and Observer Architecture:**

* Introduced a domain-driven event bus (`EventBus`) and observer (`AppEventSubscriber`) system to publish and handle app open events, with in-memory implementation (`InMemoryEventBus`). This allows decoupled handling of analytics, notification, and usage tracking logic. [[1]](diffhunk://#diff-6bd5ccabe77464d74ad7bd75d053887020fa15f841d36dfb3b9956f95dec2afbR1-R50) [[2]](diffhunk://#diff-8435712c4aa319a1749ac08816ee7141c1874b5a64ff4a5ef76a9ec8e78e1d67R1-R9) [[3]](diffhunk://#diff-b3acd4b99c29eb92d013bf2cd5ef918d58b8100fbf33e5bd60e051d971a5941cR1-R7) [[4]](diffhunk://#diff-895a96789bf1275c8b1736a444592eadf8c9f0e5504a04f4f299db37f45c216bR1-R3) [[5]](diffhunk://#diff-8c3452338744c7d3ae9549ada192707a449d51ed963ff51e0c92d63db11082baR1-R12) [[6]](diffhunk://#diff-0fa80ba0916c8c2ae52647c20bfd1730de7fc028bc9dd660bab80b20791ef7cfR1-R7) [[7]](diffhunk://#diff-e4cb08dd4e917f137cf696057f8c5604df15afb59adb7e3738bdd84b36b47aedR1-R6)
* Added observer implementations for analytics (`AnalyticsObserver`), notification preparation (`NotificationObserver`), and usage tracking (`UsageTrackerObserver`), each handling `AppOpenedEvent` in a modular way. [[1]](diffhunk://#diff-3dad9e86632d165754c9a8f419a41bf70cbfdf7e1a9c2eaf29e5be280305a789R1-R21) [[2]](diffhunk://#diff-6880eb931d7d2c1cbe9278d6fdd26091c6543e220119c1da5ff564efd2fdbaecR1-R21) [[3]](diffhunk://#diff-5c866cd906575b64fe3509cfa030cf3e6f375e77802ec84a6a9f053e416acfb8R1-R21)
* Implemented repositories for each observer, including a Firestore-backed repository for persisting raw app open events (`FirebaseAppOpenTrackingRepository`). [[1]](diffhunk://#diff-ce0239f320802a00b4ec14bf55a3b9187cc265483a69b73b48a3286d5f2425e7R1-R17) [[2]](diffhunk://#diff-937415f1da4f11cbe08988ce6d2e9d837fb28387db165ebf6eabd28b896b157dR1-R17) [[3]](diffhunk://#diff-27b385b7d014b835f9b4ce372e9f16c14deac41f5073216a4a6a41b5eca0d5e7R1-R58)

**Lifecycle Integration and Debouncing:**

* Added `AppForegroundLifecycleObserver` to track app foreground events for signed-in users, triggering event publication only when appropriate. Integrated this observer with the app's process lifecycle in `WheelsApplication`. [[1]](diffhunk://#diff-a4a64781771d5e9985ada3f832a7c6241e2aaf5de317272695c7e093593e9446R4-R19) [[2]](diffhunk://#diff-c79a1aa4e8c1a340dc1a1f5c7e076d0606d3bafdcb38ee4c7a826d240f60f4e3R1-R41)
* Introduced `AppOpenEventDebouncer` to prevent duplicate event publication within a short time window, avoiding double-counting during login/session restore and foreground transitions.

**Notification Permission Handling:**

* Updated `MainActivity` to request notification permission on Android 13+ at app launch, decoupling this flow from messaging service logic and ensuring FCM notifications can be shown. [[1]](diffhunk://#diff-f0cc9fd90049a847d0da02e312aad727603b68eebc395a8bb4c5f3e50d8c069eR3-R10) [[2]](diffhunk://#diff-f0cc9fd90049a847d0da02e312aad727603b68eebc395a8bb4c5f3e50d8c069eR20-R28) [[3]](diffhunk://#diff-f0cc9fd90049a847d0da02e312aad727603b68eebc395a8bb4c5f3e50d8c069eR38-R53)

**Dependency and Submodule Updates:**

* Added `androidx.lifecycle:lifecycle-process` dependency to support process lifecycle observation.
* Removed subproject commits for `Firebase-functions` and `Flutter`, likely as part of repo cleanup or restructuring. [[1]](diffhunk://#diff-5dbe903f462d1d6cecd2b70bba310463447277fd73938c27ca3ec761e9244494L1) [[2]](diffhunk://#diff-c903759742b75021c0daffedc7592cbc303fce8d37909a875f7eac996ae266d2L1)

Closes #58 