### PR TITLE
Implement role change tracking feature with Firebase integration

### DIFF
--- a/app/src/main/java/com/wheels/app/core/analytics/data/repository/FirebaseRoleChangeEventRepository.kt
+++ b/app/src/main/java/com/wheels/app/core/analytics/data/repository/FirebaseRoleChangeEventRepository.kt
@@ -1,0 +1,64 @@
+package com.wheels.app.core.analytics.data.repository
+
+import com.google.android.gms.tasks.Task
+import com.google.firebase.firestore.FieldValue
+import com.google.firebase.firestore.FirebaseFirestore
+import com.wheels.app.core.analytics.domain.model.RoleChangeEvent
+import com.wheels.app.core.analytics.domain.repository.RoleChangeEventRepository
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+
+@Singleton
+class FirebaseRoleChangeEventRepository @Inject constructor(
+    private val firestore: FirebaseFirestore,
+    private val ioDispatcher: CoroutineDispatcher
+) : RoleChangeEventRepository {
+
+    override suspend fun trackRoleChange(event: RoleChangeEvent) {
+        withContext(ioDispatcher) {
+            val eventId = buildEventId(event)
+            // Append-only event collection. This is ideal for BigQuery streaming
+            // and Looker Studio dashboards because each role change becomes one row.
+            firestore.collection(ROLE_CHANGE_EVENTS_COLLECTION)
+                .document(eventId)
+                .set(
+                    mapOf(
+                        "uid" to event.uid,
+                        "email" to event.email,
+                        "oldRole" to event.oldRole,
+                        "newRole" to event.newRole,
+                        "sourceScreen" to event.sourceScreen,
+                        "sourceAction" to event.sourceAction,
+                        "changedAt" to event.changedAtMillis,
+                        "changedHour" to event.changedHour,
+                        "changedMinute" to event.changedMinute,
+                        "changedMonthKey" to event.changedMonthKey,
+                        "timezone" to event.timezone,
+                        "createdAt" to FieldValue.serverTimestamp()
+                    )
+                )
+                .awaitResult()
+        }
+    }
+
+    private fun buildEventId(event: RoleChangeEvent): String {
+        return "role_change_${event.uid}_${event.changedAtMillis}_${UUID.randomUUID()}"
+    }
+
+    private suspend fun <T> Task<T>.awaitResult(): T {
+        return suspendCancellableCoroutine { continuation ->
+            addOnSuccessListener { result -> continuation.resume(result) }
+            addOnFailureListener { exception -> continuation.resumeWithException(exception) }
+        }
+    }
+
+    private companion object {
+        const val ROLE_CHANGE_EVENTS_COLLECTION = "role_change_events"
+    }
+}

--- a/app/src/main/java/com/wheels/app/core/analytics/domain/model/RoleChangeEvent.kt
+++ b/app/src/main/java/com/wheels/app/core/analytics/domain/model/RoleChangeEvent.kt
@@ -1,0 +1,15 @@
+package com.wheels.app.core.analytics.domain.model
+
+data class RoleChangeEvent(
+    val uid: String,
+    val email: String,
+    val oldRole: String,
+    val newRole: String,
+    val sourceScreen: String,
+    val sourceAction: String,
+    val changedAtMillis: Long,
+    val changedHour: Int,
+    val changedMinute: Int,
+    val changedMonthKey: String,
+    val timezone: String
+)

--- a/app/src/main/java/com/wheels/app/core/analytics/domain/repository/RoleChangeEventRepository.kt
+++ b/app/src/main/java/com/wheels/app/core/analytics/domain/repository/RoleChangeEventRepository.kt
@@ -1,0 +1,7 @@
+package com.wheels.app.core.analytics.domain.repository
+
+import com.wheels.app.core.analytics.domain.model.RoleChangeEvent
+
+interface RoleChangeEventRepository {
+    suspend fun trackRoleChange(event: RoleChangeEvent)
+}

--- a/app/src/main/java/com/wheels/app/core/analytics/domain/usecase/TrackRoleChangeUseCase.kt
+++ b/app/src/main/java/com/wheels/app/core/analytics/domain/usecase/TrackRoleChangeUseCase.kt
@@ -1,0 +1,50 @@
+package com.wheels.app.core.analytics.domain.usecase
+
+import com.wheels.app.core.analytics.domain.model.RoleChangeEvent
+import com.wheels.app.core.analytics.domain.repository.RoleChangeEventRepository
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import javax.inject.Inject
+
+class TrackRoleChangeUseCase @Inject constructor(
+    private val roleChangeEventRepository: RoleChangeEventRepository
+) {
+    suspend operator fun invoke(
+        uid: String,
+        email: String,
+        oldRole: String,
+        newRole: String,
+        sourceScreen: String = "Profile",
+        sourceAction: String = "role_change"
+    ) {
+        if (uid.isBlank() || email.isBlank()) return
+        if (oldRole.isBlank() || newRole.isBlank()) return
+
+        val now = Instant.now()
+        val zoneId = ZoneId.systemDefault()
+        val zonedDateTime = now.atZone(zoneId)
+
+        // Store the timestamp in a reporting-friendly shape so BigQuery or
+        // Looker Studio can group by month, hour, or weekday without extra parsing.
+        val event = RoleChangeEvent(
+            uid = uid,
+            email = email,
+            oldRole = oldRole,
+            newRole = newRole,
+            sourceScreen = sourceScreen,
+            sourceAction = sourceAction,
+            changedAtMillis = now.toEpochMilli(),
+            changedHour = zonedDateTime.hour,
+            changedMinute = zonedDateTime.minute,
+            changedMonthKey = zonedDateTime.format(MONTH_KEY_FORMATTER),
+            timezone = zoneId.id
+        )
+
+        roleChangeEventRepository.trackRoleChange(event)
+    }
+
+    private companion object {
+        val MONTH_KEY_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM")
+    }
+}

--- a/app/src/main/java/com/wheels/app/core/di/RepositoryModule.kt
+++ b/app/src/main/java/com/wheels/app/core/di/RepositoryModule.kt
@@ -1,7 +1,9 @@
 package com.wheels.app.core.di
 
 import com.wheels.app.core.analytics.data.repository.FirebaseUserDestinationInsightsRepository
+import com.wheels.app.core.analytics.data.repository.FirebaseRoleChangeEventRepository
 import com.wheels.app.core.analytics.domain.repository.UserDestinationInsightsRepository
+import com.wheels.app.core.analytics.domain.repository.RoleChangeEventRepository
 import com.wheels.app.core.location.data.provider.FusedCurrentLocationProvider
 import com.wheels.app.core.location.domain.provider.CurrentLocationProvider
 import com.wheels.app.core.session.data.repository.FirebaseUserSessionMetadataRepository
@@ -31,6 +33,12 @@ abstract class RepositoryModule {
     abstract fun bindUserDestinationInsightsRepository(
         impl: FirebaseUserDestinationInsightsRepository
     ): UserDestinationInsightsRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindRoleChangeEventRepository(
+        impl: FirebaseRoleChangeEventRepository
+    ): RoleChangeEventRepository
 
     @Binds
     @Singleton

--- a/app/src/main/java/com/wheels/app/features/profile/presentation/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/com/wheels/app/features/profile/presentation/viewmodel/ProfileViewModel.kt
@@ -3,6 +3,7 @@ package com.wheels.app.features.profile.presentation.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wheels.app.core.common.Resource
+import com.wheels.app.core.analytics.domain.usecase.TrackRoleChangeUseCase
 import com.wheels.app.core.session.RoleManager
 import com.wheels.app.core.session.UserRole
 import com.wheels.app.core.trust.domain.repository.DriverTrustRepository
@@ -29,7 +30,8 @@ class ProfileViewModel @Inject constructor(
     private val driverTrustRepository: DriverTrustRepository,
     private val signOutUseCase: SignOutUseCase,
     private val switchActiveRoleUseCase: SwitchActiveRoleUseCase,
-    private val registerAdditionalRoleUseCase: RegisterAdditionalRoleUseCase
+    private val registerAdditionalRoleUseCase: RegisterAdditionalRoleUseCase,
+    private val trackRoleChangeUseCase: TrackRoleChangeUseCase
 ) : ViewModel() {
 
     private var observedTrustUserId: String? = null
@@ -138,11 +140,20 @@ class ProfileViewModel @Inject constructor(
 
     private fun switchRole(role: UserRole) {
         if (roleManager.hasRole(role)) {
+            val previousRole = _uiState.value.activeRole
             viewModelScope.launch {
                 _uiState.value = _uiState.value.copy(roleActionLoading = true, roleInfoMessage = null)
                 when (val result = switchActiveRoleUseCase(role)) {
                     is Resource.Success -> {
                         roleManager.syncFromAuthUser(result.data)
+                        trackRoleChangeUseCase(
+                            uid = result.data.uid,
+                            email = result.data.email,
+                            oldRole = previousRole.storageValue,
+                            newRole = role.storageValue,
+                            sourceScreen = "Profile",
+                            sourceAction = "switch_active_role"
+                        )
                         _uiState.value = _uiState.value.copy(
                             roleActionLoading = false,
                             roleInfoMessage = "You are now using Wheels as ${role.displayName.lowercase()}."
@@ -170,12 +181,21 @@ class ProfileViewModel @Inject constructor(
     private fun confirmRoleUpgrade() {
         val targetRole = _uiState.value.roleUpgradeTarget ?: return
         val password = _uiState.value.roleUpgradePassword
+        val previousRole = _uiState.value.activeRole
 
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(roleActionLoading = true, roleUpgradeErrorMessage = null)
             when (val result = registerAdditionalRoleUseCase(targetRole, password)) {
                 is Resource.Success -> {
                     roleManager.syncFromAuthUser(result.data)
+                    trackRoleChangeUseCase(
+                        uid = result.data.uid,
+                        email = result.data.email,
+                        oldRole = previousRole.storageValue,
+                        newRole = targetRole.storageValue,
+                        sourceScreen = "Profile",
+                        sourceAction = "register_additional_role"
+                    )
                     _uiState.value = _uiState.value.copy(
                         roleActionLoading = false,
                         roleUpgradeTarget = null,

--- a/firestore.rules
+++ b/firestore.rules
@@ -56,5 +56,14 @@ service cloud.firestore {
     match /user_usage_patterns/{userId} {
       allow read, write: if false;
     }
+
+    // Demo analytics stream for role changes. The app only appends events for
+    // the authenticated user, and BigQuery / Looker Studio can read the stream
+    // through Firebase exports without the client needing read access.
+    match /role_change_events/{eventId} {
+      allow create: if isSignedIn()
+        && request.resource.data.uid == request.auth.uid;
+      allow read, update, delete: if false;
+    }
   }
 }


### PR DESCRIPTION
This pull request introduces a new analytics feature to track user role changes within the app. It adds a complete pipeline for recording detailed role change events to Firebase Firestore, making the data suitable for downstream analytics (e.g., BigQuery, Looker Studio). The implementation includes a new domain model, repository, use case, DI bindings, and integration into the `ProfileViewModel` for both role switching and upgrades. Firestore security rules are also updated to support this new event stream.

**Analytics: Role Change Tracking**

* Added a new domain model `RoleChangeEvent` to represent detailed information about user role changes, including user ID, email, old/new roles, event source, timestamp, and timezone.
* Implemented `FirebaseRoleChangeEventRepository` to persist role change events as append-only documents in the new `role_change_events` Firestore collection, ensuring compatibility with analytics tools.
* Created `RoleChangeEventRepository` interface and `TrackRoleChangeUseCase` to encapsulate and standardize the event tracking logic, formatting timestamps for reporting and grouping. [[1]](diffhunk://#diff-fd370280e15f51efdabed00c21ee22b2073ba931afc1f87a43a85017327f480eR1-R7) [[2]](diffhunk://#diff-0207f11fd8f7d71e7a26550ab6356bf2b081d610fe53b0c5542669070f21eee0R1-R50)
* Updated dependency injection bindings in `RepositoryModule` to provide the new repository implementation throughout the app. [[1]](diffhunk://#diff-e3b799fcacc2f039a9339be4fbc5f8aefbb953c064a35bb99d12fa493308c6c5R4-R6) [[2]](diffhunk://#diff-e3b799fcacc2f039a9339be4fbc5f8aefbb953c064a35bb99d12fa493308c6c5R37-R42)

**Profile Feature Integration**

* Integrated `TrackRoleChangeUseCase` into `ProfileViewModel` so that both role switches and role upgrades are tracked as analytics events, capturing all relevant context for each change. [[1]](diffhunk://#diff-3c985b92521fa49aa3eda9c447a1c62fd41401afcfe3a437353bd2d60923d920R6) [[2]](diffhunk://#diff-3c985b92521fa49aa3eda9c447a1c62fd41401afcfe3a437353bd2d60923d920L32-R34) [[3]](diffhunk://#diff-3c985b92521fa49aa3eda9c447a1c62fd41401afcfe3a437353bd2d60923d920R143-R156) [[4]](diffhunk://#diff-3c985b92521fa49aa3eda9c447a1c62fd41401afcfe3a437353bd2d60923d920R184-R198)

**Security and Firestore Rules**

* Updated Firestore security rules to allow only authenticated users to create new `role_change_events` for themselves, while disallowing reads, updates, and deletes from the client. This ensures data integrity and privacy for analytics events.