### PR TITLE
Corregido Cache sin dañar todo el repo lol

### DIFF
--- a/app/src/main/java/com/wheels/app/core/di/RepositoryModule.kt
+++ b/app/src/main/java/com/wheels/app/core/di/RepositoryModule.kt
@@ -6,6 +6,8 @@ import com.wheels.app.core.analytics.domain.repository.UserDestinationInsightsRe
 import com.wheels.app.core.analytics.domain.repository.RoleChangeEventRepository
 import com.wheels.app.core.location.data.provider.FusedCurrentLocationProvider
 import com.wheels.app.core.location.domain.provider.CurrentLocationProvider
+import com.wheels.app.core.network.AndroidNetworkMonitor
+import com.wheels.app.core.network.NetworkMonitor
 import com.wheels.app.core.session.data.repository.FirebaseUserSessionMetadataRepository
 import com.wheels.app.core.session.domain.repository.UserSessionMetadataRepository
 import com.wheels.app.core.trust.data.repository.FirebaseDriverTrustRepository
@@ -65,6 +67,10 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindCurrentLocationProvider(impl: FusedCurrentLocationProvider): CurrentLocationProvider
+
+    @Binds
+    @Singleton
+    abstract fun bindNetworkMonitor(impl: AndroidNetworkMonitor): NetworkMonitor
 
     @Binds
     @Singleton

--- a/app/src/main/java/com/wheels/app/core/network/AndroidNetworkMonitor.kt
+++ b/app/src/main/java/com/wheels/app/core/network/AndroidNetworkMonitor.kt
@@ -1,0 +1,23 @@
+package com.wheels.app.core.network
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AndroidNetworkMonitor @Inject constructor(
+    @ApplicationContext private val context: Context
+) : NetworkMonitor {
+
+    override fun isOnline(): Boolean {
+        val connectivityManager = context.getSystemService(ConnectivityManager::class.java)
+        val network = connectivityManager.activeNetwork ?: return false
+        val capabilities = connectivityManager.getNetworkCapabilities(network) ?: return false
+
+        return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
+            capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+    }
+}

--- a/app/src/main/java/com/wheels/app/core/network/NetworkMonitor.kt
+++ b/app/src/main/java/com/wheels/app/core/network/NetworkMonitor.kt
@@ -1,0 +1,5 @@
+package com.wheels.app.core.network
+
+interface NetworkMonitor {
+    fun isOnline(): Boolean
+}

--- a/app/src/main/java/com/wheels/app/features/rides/data/local/CachedNearRides.kt
+++ b/app/src/main/java/com/wheels/app/features/rides/data/local/CachedNearRides.kt
@@ -1,0 +1,8 @@
+package com.wheels.app.features.rides.data.local
+
+import com.wheels.app.features.rides.domain.model.Ride
+
+data class CachedNearRides(
+    val rides: List<Ride>,
+    val cachedAtMillis: Long
+)

--- a/app/src/main/java/com/wheels/app/features/rides/data/local/NearRidesCacheKey.kt
+++ b/app/src/main/java/com/wheels/app/features/rides/data/local/NearRidesCacheKey.kt
@@ -1,0 +1,24 @@
+package com.wheels.app.features.rides.data.local
+
+import com.wheels.app.features.rides.domain.model.NearRidesQuery
+import kotlin.math.roundToInt
+
+data class NearRidesCacheKey(
+    val latBucket: Int,
+    val lngBucket: Int,
+    val radiusMeters: Int,
+    val destinationQuery: String
+) {
+    companion object {
+        fun from(query: NearRidesQuery): NearRidesCacheKey {
+            return NearRidesCacheKey(
+                latBucket = (query.coordinates.lat * LOCATION_BUCKET_SCALE).roundToInt(),
+                lngBucket = (query.coordinates.lng * LOCATION_BUCKET_SCALE).roundToInt(),
+                radiusMeters = query.radiusMeters,
+                destinationQuery = query.destinationQuery.trim().lowercase()
+            )
+        }
+
+        private const val LOCATION_BUCKET_SCALE = 1_000.0
+    }
+}

--- a/app/src/main/java/com/wheels/app/features/rides/data/local/NearRidesLocalCache.kt
+++ b/app/src/main/java/com/wheels/app/features/rides/data/local/NearRidesLocalCache.kt
@@ -1,0 +1,32 @@
+package com.wheels.app.features.rides.data.local
+
+import android.util.LruCache
+import com.wheels.app.features.rides.domain.model.NearRidesQuery
+import com.wheels.app.features.rides.domain.model.Ride
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class NearRidesLocalCache @Inject constructor() {
+    private val memoryCache = LruCache<NearRidesCacheKey, CachedNearRides>(MAX_ENTRIES)
+
+    @Synchronized
+    fun get(query: NearRidesQuery): CachedNearRides? {
+        return memoryCache.get(NearRidesCacheKey.from(query))
+    }
+
+    @Synchronized
+    fun put(query: NearRidesQuery, rides: List<Ride>) {
+        memoryCache.put(
+            NearRidesCacheKey.from(query),
+            CachedNearRides(
+                rides = rides,
+                cachedAtMillis = System.currentTimeMillis()
+            )
+        )
+    }
+
+    companion object {
+        private const val MAX_ENTRIES = 32
+    }
+}

--- a/app/src/main/java/com/wheels/app/features/rides/data/remote/NearRidesRemoteDataSource.kt
+++ b/app/src/main/java/com/wheels/app/features/rides/data/remote/NearRidesRemoteDataSource.kt
@@ -1,0 +1,25 @@
+package com.wheels.app.features.rides.data.remote
+
+import com.wheels.app.features.rides.data.remote.api.RideApi
+import com.wheels.app.features.rides.data.remote.mapper.toDomain
+import com.wheels.app.features.rides.domain.model.NearRidesQuery
+import com.wheels.app.features.rides.domain.model.Ride
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+
+@Singleton
+class NearRidesRemoteDataSource @Inject constructor(
+    private val rideApi: RideApi,
+    private val ioDispatcher: CoroutineDispatcher
+) {
+    suspend fun fetchNearRides(query: NearRidesQuery): List<Ride> = withContext(ioDispatcher) {
+        rideApi.getNearRides(
+            latitude = query.coordinates.lat,
+            longitude = query.coordinates.lng,
+            radiusMeters = query.radiusMeters,
+            destinationQuery = query.destinationQuery.ifBlank { null }
+        ).map { dto -> dto.toDomain() }
+    }
+}

--- a/app/src/main/java/com/wheels/app/features/rides/data/remote/api/RideApi.kt
+++ b/app/src/main/java/com/wheels/app/features/rides/data/remote/api/RideApi.kt
@@ -2,8 +2,17 @@ package com.wheels.app.features.rides.data.remote.api
 
 import com.wheels.app.features.rides.data.remote.dto.RideDto
 import retrofit2.http.GET
+import retrofit2.http.Query
 
 interface RideApi {
     @GET("rides/available")
     suspend fun getAvailableRides(): List<RideDto>
+
+    @GET("rides/near")
+    suspend fun getNearRides(
+        @Query("lat") latitude: Double,
+        @Query("lng") longitude: Double,
+        @Query("radiusMeters") radiusMeters: Int,
+        @Query("destination") destinationQuery: String? = null
+    ): List<RideDto>
 }

--- a/app/src/main/java/com/wheels/app/features/rides/data/repository/RideRepositoryImpl.kt
+++ b/app/src/main/java/com/wheels/app/features/rides/data/repository/RideRepositoryImpl.kt
@@ -6,9 +6,14 @@ import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.GeoPoint
 import com.google.firebase.firestore.QuerySnapshot
+import com.wheels.app.core.common.Resource
+import com.wheels.app.core.network.NetworkMonitor
+import com.wheels.app.features.rides.data.local.NearRidesLocalCache
+import com.wheels.app.features.rides.data.remote.NearRidesRemoteDataSource
 import com.wheels.app.features.rides.domain.model.Booking
 import com.wheels.app.features.rides.domain.model.Coordinates
 import com.wheels.app.features.rides.domain.model.DriverRideRecord
+import com.wheels.app.features.rides.domain.model.NearRidesQuery
 import com.wheels.app.features.rides.domain.model.PublishRideRequest
 import com.wheels.app.features.rides.domain.model.Ride
 import com.wheels.app.features.rides.domain.repository.RideRepository
@@ -17,15 +22,22 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
 
 @Singleton
 class RideRepositoryImpl @Inject constructor(
-    private val firestore: FirebaseFirestore
+    private val firestore: FirebaseFirestore,
+    private val nearRidesRemoteDataSource: NearRidesRemoteDataSource,
+    private val nearRidesLocalCache: NearRidesLocalCache,
+    private val networkMonitor: NetworkMonitor,
+    private val ioDispatcher: CoroutineDispatcher
 ) : RideRepository {
 
     override fun getAvailableRides(): Flow<List<Ride>> = callbackFlow {
@@ -67,6 +79,47 @@ class RideRepositoryImpl @Inject constructor(
             }
 
         awaitClose { registration.remove() }
+    }
+
+    override fun getNearRides(query: NearRidesQuery): Flow<Resource<List<Ride>>> = flow {
+        val cached = withContext(ioDispatcher) {
+            nearRidesLocalCache.get(query)
+        }
+
+        if (cached != null) {
+            emit(Resource.Success(cached.rides))
+        } else {
+            emit(Resource.Loading)
+        }
+
+        val isOnline = withContext(ioDispatcher) {
+            networkMonitor.isOnline()
+        }
+
+        if (!isOnline) {
+            if (cached == null) {
+                emit(Resource.Error("No connection. Connect to the internet to find nearby rides."))
+            }
+            return@flow
+        }
+
+        runCatching {
+            nearRidesRemoteDataSource.fetchNearRides(query)
+        }.onSuccess { freshRides ->
+            withContext(ioDispatcher) {
+                nearRidesLocalCache.put(query, freshRides)
+            }
+            emit(Resource.Success(freshRides))
+        }.onFailure { throwable ->
+            if (cached == null) {
+                emit(
+                    Resource.Error(
+                        message = throwable.message ?: "Near rides are unavailable right now.",
+                        throwable = throwable
+                    )
+                )
+            }
+        }
     }
 
     override fun observeRide(rideId: String): Flow<Ride?> = callbackFlow {

--- a/app/src/main/java/com/wheels/app/features/rides/domain/model/NearRidesQuery.kt
+++ b/app/src/main/java/com/wheels/app/features/rides/domain/model/NearRidesQuery.kt
@@ -1,0 +1,11 @@
+package com.wheels.app.features.rides.domain.model
+
+data class NearRidesQuery(
+    val coordinates: Coordinates,
+    val radiusMeters: Int = DEFAULT_RADIUS_METERS,
+    val destinationQuery: String = ""
+) {
+    companion object {
+        const val DEFAULT_RADIUS_METERS = 3_000
+    }
+}

--- a/app/src/main/java/com/wheels/app/features/rides/domain/repository/RideRepository.kt
+++ b/app/src/main/java/com/wheels/app/features/rides/domain/repository/RideRepository.kt
@@ -1,13 +1,16 @@
 package com.wheels.app.features.rides.domain.repository
 
+import com.wheels.app.core.common.Resource
 import com.wheels.app.features.rides.domain.model.Booking
 import com.wheels.app.features.rides.domain.model.DriverRideRecord
+import com.wheels.app.features.rides.domain.model.NearRidesQuery
 import com.wheels.app.features.rides.domain.model.PublishRideRequest
 import com.wheels.app.features.rides.domain.model.Ride
 import kotlinx.coroutines.flow.Flow
 
 interface RideRepository {
     fun getAvailableRides(): Flow<List<Ride>>
+    fun getNearRides(query: NearRidesQuery): Flow<Resource<List<Ride>>>
     fun observeRide(rideId: String): Flow<Ride?>
     fun observeDriverRides(driverId: String): Flow<List<DriverRideRecord>>
     suspend fun publishRide(request: PublishRideRequest): String

--- a/app/src/main/java/com/wheels/app/features/rides/domain/usecase/GetNearRidesUseCase.kt
+++ b/app/src/main/java/com/wheels/app/features/rides/domain/usecase/GetNearRidesUseCase.kt
@@ -1,0 +1,16 @@
+package com.wheels.app.features.rides.domain.usecase
+
+import com.wheels.app.core.common.Resource
+import com.wheels.app.features.rides.domain.model.NearRidesQuery
+import com.wheels.app.features.rides.domain.model.Ride
+import com.wheels.app.features.rides.domain.repository.RideRepository
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+
+class GetNearRidesUseCase @Inject constructor(
+    private val rideRepository: RideRepository
+) {
+    operator fun invoke(query: NearRidesQuery): Flow<Resource<List<Ride>>> {
+        return rideRepository.getNearRides(query)
+    }
+}

--- a/app/src/main/java/com/wheels/app/features/rides/presentation/ui/NearRidesScreen.kt
+++ b/app/src/main/java/com/wheels/app/features/rides/presentation/ui/NearRidesScreen.kt
@@ -1,0 +1,100 @@
+package com.wheels.app.features.rides.presentation.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.wheels.app.features.rides.presentation.viewmodel.NearRideCardUiModel
+import com.wheels.app.features.rides.presentation.viewmodel.NearRidesViewModel
+
+@Composable
+fun NearRidesScreen(
+    viewModel: NearRidesViewModel,
+    onRideSelected: (String) -> Unit
+) {
+    val state by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.loadNearRides()
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        OutlinedTextField(
+            value = state.destinationQuery,
+            onValueChange = viewModel::loadNearRides,
+            modifier = Modifier.fillMaxWidth(),
+            label = { Text("Destination") },
+            singleLine = true
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Button(
+            onClick = { viewModel.loadNearRides() },
+            enabled = !state.isLoading
+        ) {
+            Text(if (state.isLoading) "Loading..." else "Refresh near rides")
+        }
+
+        state.errorMessage?.let { message ->
+            Text(
+                text = message,
+                modifier = Modifier.padding(top = 12.dp),
+                color = MaterialTheme.colorScheme.error
+            )
+        }
+
+        LazyColumn(modifier = Modifier.padding(top = 12.dp)) {
+            items(state.rides, key = { it.id }) { ride ->
+                NearRideCard(
+                    ride = ride,
+                    onClick = { onRideSelected(ride.id) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun NearRideCard(
+    ride: NearRideCardUiModel,
+    onClick: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 6.dp)
+            .clickable(onClick = onClick)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(text = ride.destination, style = MaterialTheme.typography.titleMedium)
+            Text(text = "From ${ride.origin}", style = MaterialTheme.typography.bodyMedium)
+            Row(modifier = Modifier.padding(top = 8.dp)) {
+                Text(text = ride.departureTime)
+                Spacer(modifier = Modifier.weight(1f))
+                Text(text = "$${ride.price} · ${ride.availableSeats} seats")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/wheels/app/features/rides/presentation/viewmodel/NearRidesViewModel.kt
+++ b/app/src/main/java/com/wheels/app/features/rides/presentation/viewmodel/NearRidesViewModel.kt
@@ -1,0 +1,152 @@
+package com.wheels.app.features.rides.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wheels.app.core.common.Resource
+import com.wheels.app.core.location.domain.model.CurrentCoordinates
+import com.wheels.app.core.location.domain.provider.CurrentLocationProvider
+import com.wheels.app.features.rides.domain.model.Coordinates
+import com.wheels.app.features.rides.domain.model.NearRidesQuery
+import com.wheels.app.features.rides.domain.model.Ride
+import com.wheels.app.features.rides.domain.usecase.GetNearRidesUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import java.time.format.DateTimeFormatter
+import javax.inject.Inject
+import kotlin.math.roundToInt
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+@HiltViewModel
+class NearRidesViewModel @Inject constructor(
+    private val getNearRidesUseCase: GetNearRidesUseCase,
+    private val currentLocationProvider: CurrentLocationProvider
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(NearRidesUiState())
+    val uiState: StateFlow<NearRidesUiState> = _uiState.asStateFlow()
+
+    private var loadNearRidesJob: Job? = null
+    private var lastKnownCoordinates: CurrentCoordinates? = null
+
+    fun loadNearRides(destinationQuery: String = _uiState.value.destinationQuery) {
+        loadNearRidesJob?.cancel()
+        loadNearRidesJob = viewModelScope.launch(Dispatchers.Main.immediate) {
+            updateUi {
+                it.copy(
+                    isLoading = true,
+                    destinationQuery = destinationQuery,
+                    errorMessage = null
+                )
+            }
+
+            val coordinatesResult = runCatching {
+                withContext(Dispatchers.IO) {
+                    currentLocationProvider.getCurrentCoordinates()
+                }
+            }
+
+            val coordinates = coordinatesResult
+                .onSuccess { coordinates -> lastKnownCoordinates = coordinates }
+                .getOrElse { throwable ->
+                    lastKnownCoordinates ?: run {
+                        updateUi {
+                            it.copy(
+                                isLoading = false,
+                                errorMessage = throwable.message ?: "We could not read your location."
+                            )
+                        }
+                        return@launch
+                    }
+                }
+
+            if (coordinatesResult.isFailure) {
+                updateUi {
+                    it.copy(
+                        errorMessage = "Using your last known location while we refresh nearby rides."
+                    )
+                }
+            }
+
+            val query = NearRidesQuery(
+                coordinates = Coordinates(
+                    lat = coordinates.latitude,
+                    lng = coordinates.longitude
+                ),
+                destinationQuery = destinationQuery
+            )
+
+            getNearRidesUseCase(query)
+                .catch { throwable ->
+                    updateUi {
+                        it.copy(
+                            isLoading = false,
+                            errorMessage = throwable.message ?: "Near rides are unavailable right now."
+                        )
+                    }
+                }
+                .collect { resource ->
+                    when (resource) {
+                        Resource.Loading -> updateUi { it.copy(isLoading = true) }
+                        is Resource.Success -> updateUi {
+                            it.copy(
+                                isLoading = false,
+                                rides = resource.data.toNearRideCards(),
+                                errorMessage = null
+                            )
+                        }
+                        is Resource.Error -> updateUi {
+                            it.copy(
+                                isLoading = false,
+                                errorMessage = resource.message
+                            )
+                        }
+                    }
+                }
+        }
+    }
+
+    private suspend fun updateUi(transform: (NearRidesUiState) -> NearRidesUiState) {
+        withContext(Dispatchers.Main.immediate) {
+            _uiState.update(transform)
+        }
+    }
+}
+
+data class NearRidesUiState(
+    val isLoading: Boolean = false,
+    val destinationQuery: String = "",
+    val rides: List<NearRideCardUiModel> = emptyList(),
+    val errorMessage: String? = null
+)
+
+data class NearRideCardUiModel(
+    val id: String,
+    val driver: String,
+    val origin: String,
+    val destination: String,
+    val departureTime: String,
+    val price: Int,
+    val availableSeats: Int
+)
+
+private fun List<Ride>.toNearRideCards(): List<NearRideCardUiModel> {
+    return map { ride ->
+        val departure = ride.departureTime.atZone(java.time.ZoneId.systemDefault())
+        NearRideCardUiModel(
+            id = ride.id,
+            driver = ride.driverName.ifBlank { "Uniandes driver" },
+            origin = ride.origin,
+            destination = ride.destination,
+            departureTime = departure.toLocalTime().format(DateTimeFormatter.ofPattern("HH:mm")),
+            price = ride.pricePerSeat.roundToInt(),
+            availableSeats = ride.availableSeats
+        )
+    }
+}


### PR DESCRIPTION
This pull request introduces a new "near rides" feature, enabling users to find rides close to their location, with support for destination filtering, caching, and offline handling. The implementation includes new data models, repository methods, local cache, remote data source, domain use case, ViewModel, and a Compose UI screen. Additionally, network monitoring is added to support offline scenarios.

**Near rides feature implementation:**

* Added new data models: `NearRidesQuery` (domain), `NearRidesCacheKey`, and `CachedNearRides` (data/local) to represent queries and cache keys for nearby rides. [[1]](diffhunk://#diff-3f1eedf6fb8c4190365c6f5b953fb2edee3d2c3b998dfe755af1c9add0dd2236R1-R11) [[2]](diffhunk://#diff-15ab4f4ff2bdb3c9891a82479d130476dfb164066c2b88813cf22dcf10fe013dR1-R24) [[3]](diffhunk://#diff-5ef4074531a26639a8718c154da5cda04ac487734c4847a43e313f39356677d6R1-R8)
* Implemented `NearRidesLocalCache` (in-memory LRU cache) for efficient local caching of nearby rides queries.
* Created `NearRidesRemoteDataSource` and extended `RideApi` with `getNearRides` endpoint for fetching rides from the backend. [[1]](diffhunk://#diff-87819359d66d02394a56adae84f89ae2c98dd3e41020c0925fbcd290f103728cR1-R25) [[2]](diffhunk://#diff-b080c22d48c055e4e1eef762fb79917e7030e9fb5c99ad06aa9ee828a6a4d85eR5-R17)

**Repository and domain layer changes:**

* Extended `RideRepository` and its implementation to support `getNearRides`, which combines local cache, remote fetch, and network monitoring, emitting loading, success, or error states as a `Resource`. [[1]](diffhunk://#diff-e9df7950fe7dda8ecece76147888ff262d3147832c8eafb0c9916174d2257a15R3-R13) [[2]](diffhunk://#diff-a57999b719e5a8b6921167ed550589b11092a4d0c6689c92fe6f9475b4a43000R9-R16) [[3]](diffhunk://#diff-a57999b719e5a8b6921167ed550589b11092a4d0c6689c92fe6f9475b4a43000R25-R40) [[4]](diffhunk://#diff-a57999b719e5a8b6921167ed550589b11092a4d0c6689c92fe6f9475b4a43000R84-R124)
* Added `GetNearRidesUseCase` to encapsulate the new repository method for use in the presentation layer.

**Presentation layer (ViewModel and UI):**

* Added `NearRidesViewModel` to manage UI state, handle querying, location fetching, and error handling for the near rides feature.
* Introduced a new Compose screen, `NearRidesScreen`, to display nearby rides, handle user input, and show loading/error states.

**Network monitoring:**

* Added `NetworkMonitor` interface and `AndroidNetworkMonitor` implementation, with DI bindings, to enable online/offline detection for the near rides feature. [[1]](diffhunk://#diff-14e94c0b6186c9636a8c3ad26e9496572a721c789a9625fdc2b652cc3902dad4R1-R5) [[2]](diffhunk://#diff-7c2b62e49095d532726f27bc0de1d22d932de2daa38d9fff6778c2bcfafd5158R1-R23) [[3]](diffhunk://#diff-e3b799fcacc2f039a9339be4fbc5f8aefbb953c064a35bb99d12fa493308c6c5R9-R10) [[4]](diffhunk://#diff-e3b799fcacc2f039a9339be4fbc5f8aefbb953c064a35bb99d12fa493308c6c5R71-R74)

These changes collectively provide a robust, user-friendly "near rides" experience with local caching and offline support.