### PR TITLE
Implement coroutines for multithreading in Habit-based notifications

### DIFF
--- a/app/src/main/java/com/wheels/app/core/behavior/data/bus/InMemoryEventBus.kt
+++ b/app/src/main/java/com/wheels/app/core/behavior/data/bus/InMemoryEventBus.kt
@@ -7,6 +7,9 @@ import com.wheels.app.core.behavior.domain.observer.AppEventSubscriber
 import java.util.concurrent.CopyOnWriteArraySet
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 
@@ -30,16 +33,22 @@ class InMemoryEventBus @Inject constructor(
 
     override suspend fun publish(event: AppEvent) {
         withContext(ioDispatcher) {
-            // Every subscriber receives the same event, but each one decides
-            // whether and how to react to it.
-            subscribers.forEach { subscriber ->
-                runCatching {
-                    subscriber.update(event)
-                }.onFailure { error ->
-                    // Observers are best-effort. One failing subscriber should
-                    // not crash the app or prevent the other observers from running.
-                    Log.w(TAG, "App event observer failed", error)
-                }
+            supervisorScope {
+                // Fan out the same event to each observer concurrently so
+                // tracking, analytics, and notification preparation stay
+                // isolated from one another.
+                subscribers.map { subscriber ->
+                    launch {
+                        runCatching {
+                            subscriber.update(event)
+                        }.onFailure { error ->
+                            // Observers are best-effort. One failing subscriber
+                            // should not crash the app or prevent the other
+                            // observers from running.
+                            Log.w(TAG, "App event observer failed", error)
+                        }
+                    }
+                }.joinAll()
             }
         }
     }


### PR DESCRIPTION
This pull request updates the `InMemoryEventBus` to improve the way events are published to subscribers. The main enhancement is that events are now dispatched to all subscribers concurrently, ensuring that slow or failing observers do not block others. This makes the event bus more robust and responsive.

**Concurrency and robustness improvements:**

* Modified the `publish` method in `InMemoryEventBus` to use `supervisorScope` and `launch` each subscriber update in a separate coroutine, allowing all subscribers to process events concurrently and independently. This prevents one slow or failing observer from affecting the others.
* Added imports for `kotlinx.coroutines.launch`, `kotlinx.coroutines.joinAll`, and `kotlinx.coroutines.supervisorScope` to support the new concurrent event dispatching logic.

Closes #85 