### PR TITLE
comments for dark mode

### DIFF
--- a/app/src/main/java/com/wheels/app/MainActivity.kt
+++ b/app/src/main/java/com/wheels/app/MainActivity.kt
@@ -15,6 +15,10 @@ import com.wheels.app.core.theme.ThemeSettingsViewModel
 import com.wheels.app.core.ui.theme.WheelsTheme
 import dagger.hilt.android.AndroidEntryPoint
 
+/**
+ * Main Activity: sets up Compose content and applies the computed theme to entire app.
+ * Subscribes to ThemeSettingsViewModel to get effectiveDarkTheme and reapply when it changes.
+ */
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
@@ -22,16 +26,24 @@ class MainActivity : ComponentActivity() {
         ActivityResultContracts.RequestPermission(),
     ) { /* No-op: the service checks permission before posting notifications. */ }
 
+    // Initialize Compose with theme management
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         requestNotificationPermissionIfNeeded()
 
+        // Set Compose as the main UI framework
         setContent {
-            val themeViewModel: ThemeSettingsViewModel = hiltViewModel()
-            val themeState = themeViewModel.uiState.collectAsStateWithLifecycle()
+        // Get ThemeSettingsViewModel and subscribe to theme state
+        // Hilt automatically injects ThemePreferencesRepository and AmbientLightMonitor
+        val themeViewModel: ThemeSettingsViewModel = hiltViewModel()
+            
+        // Collect theme state and apply to entire app
+        // effectiveDarkTheme: computed based on adaptive logic or manual preference
+        val themeState = themeViewModel.uiState.collectAsStateWithLifecycle()
 
-            WheelsTheme(darkTheme = themeState.value.effectiveDarkTheme) {
-                WheelsNavGraph(themeViewModel = themeViewModel)
+        // Apply effectiveDarkTheme to entire app via WheelsTheme wrapper
+        WheelsTheme(darkTheme = themeState.value.effectiveDarkTheme) {
+            WheelsNavGraph(themeViewModel = themeViewModel)
             }
         }
     }

--- a/app/src/main/java/com/wheels/app/core/theme/AmbientLightMonitor.kt
+++ b/app/src/main/java/com/wheels/app/core/theme/AmbientLightMonitor.kt
@@ -13,46 +13,68 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 
+// Represents ambient light sensor state: whether sensor is available and current lux reading
+// Lux < 30 = dark environment (triggers dark theme), >= 30 = bright (light theme)
 data class AmbientLightState(
     val isLightSensorAvailable: Boolean,
     val ambientLux: Float? = null
 )
 
+/**
+ * Monitors device light sensor and emits ambient light readings for adaptive theme.
+ * Unregisters listener when Flow is disposed to save battery.
+ */
 @Singleton
 class AmbientLightMonitor @Inject constructor(
     @ApplicationContext context: Context
 ) {
+    // Get SensorManager from Android system
     private val sensorManager = context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
+    
+    // Get light sensor from device, or null if not available
     private val lightSensor: Sensor? = sensorManager.getDefaultSensor(Sensor.TYPE_LIGHT)
 
+    // Observable Flow of ambient light readings. Emits immediately when subscribed.
+    // If no sensor: emits false then closes. If sensor: emits readings and updates on changes.
     val ambientLightState: Flow<AmbientLightState> = callbackFlow {
         val sensor = lightSensor
+        
+        // If device doesn't have light sensor, emit once and close
         if (sensor == null) {
             trySend(AmbientLightState(isLightSensorAvailable = false))
             close()
             return@callbackFlow
         }
 
+        // Sensor is available, emit initial state
         trySend(AmbientLightState(isLightSensorAvailable = true))
 
+        // Create listener to receive sensor events
         val listener = object : SensorEventListener {
+            // Emit new light reading when sensor value changes
             override fun onSensorChanged(event: SensorEvent) {
                 val lux = event.values.firstOrNull()
                 trySend(
                     AmbientLightState(
                         isLightSensorAvailable = true,
-                        ambientLux = lux
+                        ambientLux = lux  // Illuminance in lux
                     )
                 )
             }
 
+            // Called when sensor accuracy changes (not used here)
             override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) = Unit
         }
 
+        // Register listener: Android calls onSensorChanged() when light level changes
+        // SENSOR_DELAY_NORMAL = ~200ms updates (balance between responsiveness and battery)
         sensorManager.registerListener(listener, sensor, SensorManager.SENSOR_DELAY_NORMAL)
 
+        // Cleanup when Flow is disposed: unregister listener to prevent battery drain
         awaitClose {
             sensorManager.unregisterListener(listener)
         }
-    }.distinctUntilChanged()
+    }
+    // Skip duplicate readings to reduce Flow emissions when light level doesn't change
+    .distinctUntilChanged()
 }

--- a/app/src/main/java/com/wheels/app/core/theme/ThemePreferencesRepository.kt
+++ b/app/src/main/java/com/wheels/app/core/theme/ThemePreferencesRepository.kt
@@ -10,49 +10,81 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
 
+// Domain model for theme configuration stored in SharedPreferences
+// isDarkModeEnabled: manual dark mode, isAdaptiveThemeEnabled: light sensor-based theme
 data class ThemePreferences(
     val isDarkModeEnabled: Boolean = false,
     val isAdaptiveThemeEnabled: Boolean = false
 )
 
+/**
+ * Repository for persisting and managing theme preferences.
+ * Reads from SharedPreferences, exposes as reactive Flow for subscribers.
+ */
 @Singleton
 class ThemePreferencesRepository @Inject constructor(
     @ApplicationContext context: Context,
     private val ioDispatcher: CoroutineDispatcher
 ) {
+    // Initialize SharedPreferences with private mode (only this app can access)
+    // Named "theme_preferences" to isolate theme data from other preferences
     private val sharedPreferences = context.getSharedPreferences(
         THEME_PREFERENCES_NAME,
         Context.MODE_PRIVATE
     )
 
+    // In-memory reactive state: initialized by reading current preferences from disk
     private val preferencesState = MutableStateFlow(readPreferences())
 
+    // Public Flow API: consumers subscribe here to receive preference updates
+    // Using asStateFlow() makes it read-only from outside, preventing external modifications
     val themePreferences: Flow<ThemePreferences> = preferencesState.asStateFlow()
 
+    // Persist dark mode preference to SharedPreferences and update Flow
+    // Runs on IO Dispatcher to avoid blocking main thread
     suspend fun setDarkModeEnabled(enabled: Boolean) {
         withContext(ioDispatcher) {
+            // Persist to disk and check if write was successful
             val didPersist = sharedPreferences.edit()
                 .putBoolean(DARK_MODE_ENABLED, enabled)
-                .commit()
+                .commit()  // commit() = synchronous write
 
+            // Only update in-memory state if persistence succeeded
+            // This ensures state reflects what's actually on disk
             if (didPersist) {
                 preferencesState.value = preferencesState.value.copy(isDarkModeEnabled = enabled)
             }
         }
     }
 
+    // Persist adaptive theme preference to SharedPreferences and update Flow
+    // When enabled, light sensor controls theme; otherwise manual preference used
     suspend fun setAdaptiveThemeEnabled(enabled: Boolean) {
         withContext(ioDispatcher) {
+            // Persist to disk and check if write was successful
             val didPersist = sharedPreferences.edit()
                 .putBoolean(ADAPTIVE_THEME_ENABLED, enabled)
-                .commit()
+                .commit()  // commit() = synchronous write
 
+            // Only update in-memory state if persistence succeeded
             if (didPersist) {
                 preferencesState.value = preferencesState.value.copy(isAdaptiveThemeEnabled = enabled)
             }
         }
     }
 
+    /**
+     * Reads theme preferences from SharedPreferences into domain model.
+     * Called on app startup to initialize in-memory state.
+     *
+     * BEHAVIOR:
+     * - Default values (false) are used if keys don't exist in SharedPreferences
+     * - Runs synchronously but on IO thread to avoid ANR
+     *
+     * @return ThemePreferences with values from disk or defaults
+     */
+    // Read theme preferences from SharedPreferences into domain model
+    // Uses default values if keys don't exist
     private fun readPreferences(): ThemePreferences {
         return ThemePreferences(
             isDarkModeEnabled = sharedPreferences.getBoolean(DARK_MODE_ENABLED, false),
@@ -61,8 +93,15 @@ class ThemePreferencesRepository @Inject constructor(
     }
 
     private companion object {
+        // SharedPreferences file name - used to isolate theme data from other app preferences
         const val THEME_PREFERENCES_NAME = "theme_preferences"
+        
+        // Key for dark mode enabled flag in SharedPreferences
         const val DARK_MODE_ENABLED = "dark_mode_enabled"
+        
+        // Key for adaptive theme enabled flag in SharedPreferences
+        // When true: theme adapts based on ambient light sensor readings
+        // When false: theme follows isDarkModeEnabled user choice
         const val ADAPTIVE_THEME_ENABLED = "adaptive_theme_enabled"
     }
 }

--- a/app/src/main/java/com/wheels/app/core/theme/ThemeSettingsViewModel.kt
+++ b/app/src/main/java/com/wheels/app/core/theme/ThemeSettingsViewModel.kt
@@ -10,6 +10,8 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
+// UI state for theme settings: includes preferences, sensor data, and computed effective theme
+// effectiveDarkTheme: actual theme being applied (based on adaptive logic or manual setting)
 data class ThemeSettingsUiState(
     val isDarkModeEnabled: Boolean = false,
     val isAdaptiveThemeEnabled: Boolean = false,
@@ -18,42 +20,57 @@ data class ThemeSettingsUiState(
     val isLightSensorAvailable: Boolean = false
 )
 
+/**
+ * Manages theme settings and determines effective theme based on preferences and sensor data.
+ * Combines ThemePreferencesRepository (user prefs) and AmbientLightMonitor (light sensor).
+ */
 @HiltViewModel
 class ThemeSettingsViewModel @Inject constructor(
     private val themePreferencesRepository: ThemePreferencesRepository,
     ambientLightMonitor: AmbientLightMonitor
 ) : ViewModel() {
 
+    /**
+     * Combines preferences (SharedPreferences) and sensor readings (light sensor) to compute effective theme.
+     * MainActivity and UiThemeScreen subscribe to this to get current theme state.
+     */
     val uiState: StateFlow<ThemeSettingsUiState> = combine(
-        themePreferencesRepository.themePreferences,
-        ambientLightMonitor.ambientLightState
+        themePreferencesRepository.themePreferences,  // Flow from SharedPreferences
+        ambientLightMonitor.ambientLightState        // Flow from light sensor
     ) { preferences, ambientLightState ->
+        // Determine which theme to apply: if adaptive enabled + sensor available, use light sensor
+        // Otherwise use manual isDarkModeEnabled preference
         val effectiveDarkTheme = when {
             preferences.isAdaptiveThemeEnabled && ambientLightState.isLightSensorAvailable ->
                 (ambientLightState.ambientLux ?: Float.MAX_VALUE) < LOW_LIGHT_THRESHOLD_LUX
-            else -> preferences.isDarkModeEnabled
+            else -> preferences.isDarkModeEnabled  // Use manual preference
         }
 
+        // Build complete UI state to expose to UI layer
         ThemeSettingsUiState(
             isDarkModeEnabled = preferences.isDarkModeEnabled,
             isAdaptiveThemeEnabled = preferences.isAdaptiveThemeEnabled,
-            effectiveDarkTheme = effectiveDarkTheme,
+            effectiveDarkTheme = effectiveDarkTheme,  // This is what MainActivity uses!
             ambientLux = ambientLightState.ambientLux,
             isLightSensorAvailable = ambientLightState.isLightSensorAvailable
         )
     }
         .stateIn(
             scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5_000),
+            started = SharingStarted.WhileSubscribed(5_000),  // Cache for 5 seconds when no subscribers
             initialValue = ThemeSettingsUiState()
         )
 
+    // Save dark mode preference to SharedPreferences, triggers theme recompute and app recomposition
+    // Notifies MainActivity and UiThemeScreen of the change
     fun setDarkModeEnabled(enabled: Boolean) {
         viewModelScope.launch {
             themePreferencesRepository.setDarkModeEnabled(enabled)
         }
     }
 
+    // Save adaptive theme preference to SharedPreferences, light sensor now controls theme if enabled
+    // Dark mode toggle becomes disabled in UI when this is turned on
     fun setAdaptiveThemeEnabled(enabled: Boolean) {
         viewModelScope.launch {
             themePreferencesRepository.setAdaptiveThemeEnabled(enabled)
@@ -61,6 +78,9 @@ class ThemeSettingsViewModel @Inject constructor(
     }
 
     private companion object {
+        // Ambient light threshold for deciding dark vs light theme
+        // Values below 30 lux indicate low light (night/indoor), so use dark theme
+        // Values >= 30 lux indicate normal/bright light, so use light theme
         const val LOW_LIGHT_THRESHOLD_LUX = 30f
     }
 }

--- a/app/src/main/java/com/wheels/app/features/profile/presentation/ui/UiThemeScreen.kt
+++ b/app/src/main/java/com/wheels/app/features/profile/presentation/ui/UiThemeScreen.kt
@@ -44,13 +44,20 @@ import com.wheels.app.core.ui.theme.GradientHeaderSecondaryContent
 import com.wheels.app.core.theme.ThemeSettingsViewModel
 import com.wheels.app.core.ui.theme.gradientHeaderBrush
 
+/**
+ * Theme settings screen: displays and allows configuration of theme preferences.
+ * Saves changes to SharedPreferences and triggers app-wide theme updates.
+ */
 @Composable
 fun UiThemeScreen(
     innerPadding: PaddingValues,
     navController: NavController,
     viewModel: ThemeSettingsViewModel
 ) {
+    // Subscribe to theme state from ViewModel. Recomposes when state changes.
     val themeState = viewModel.uiState.collectAsStateWithLifecycle()
+    
+    // Extract theme settings from state for easy access
     val darkModeEnabled = themeState.value.isDarkModeEnabled
     val adaptiveThemeEnabled = themeState.value.isAdaptiveThemeEnabled
     val colorScheme = MaterialTheme.colorScheme
@@ -66,6 +73,7 @@ fun UiThemeScreen(
                 .padding(innerPadding),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
+            // Header section with description
             item {
                 Box(
                     modifier = Modifier
@@ -117,6 +125,7 @@ fun UiThemeScreen(
                 }
             }
 
+            // Settings card with toggles
             item {
                 Card(
                     modifier = Modifier
@@ -127,12 +136,13 @@ fun UiThemeScreen(
                     elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
                 ) {
                     Column(modifier = Modifier.padding(20.dp)) {
+                        // Dark Mode toggle: disabled when Adaptive theme is on (sensor controls theme instead)
                         ThemeSwitchRow(
                             icon = if (darkModeEnabled) Icons.Outlined.DarkMode else Icons.Outlined.LightMode,
                             title = "Dark mode",
                             subtitle = if (darkModeEnabled) "Enabled" else "Disabled",
                             checked = darkModeEnabled,
-                            enabled = !adaptiveThemeEnabled,
+                            enabled = !adaptiveThemeEnabled,  // Disabled if adaptive theme is on
                             onCheckedChange = viewModel::setDarkModeEnabled
                         )
 
@@ -142,6 +152,7 @@ fun UiThemeScreen(
                             modifier = Modifier.fillMaxWidth()
                         )
 
+                        // Adaptive Theme toggle: when ON, light sensor controls theme automatically
                         ThemeSwitchRow(
                             icon = Icons.Outlined.WbSunny,
                             title = "Adaptive UI Theme",
@@ -157,6 +168,10 @@ fun UiThemeScreen(
     }
 }
 
+/**
+ * Reusable component for displaying a theme setting toggle.
+ * When enabled: functional with normal colors. When disabled: grayed out and non-functional.
+ */
 @Composable
 private fun ThemeSwitchRow(
     icon: androidx.compose.ui.graphics.vector.ImageVector,
@@ -175,21 +190,25 @@ private fun ThemeSwitchRow(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp)
     ) {
+        // Icon container - gray out when disabled
         Box(
             modifier = Modifier
                 .size(40.dp)
                 .clip(RoundedCornerShape(20.dp))
+                // Gray out when disabled
                 .background(if (enabled) colorScheme.surfaceVariant else colorScheme.outline.copy(alpha = 0.2f)),
             contentAlignment = Alignment.Center
         ) {
             Icon(
                 imageVector = icon,
                 contentDescription = title,
+                // Muted colors when disabled
                 tint = if (enabled) colorScheme.primary else colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
                 modifier = Modifier.size(20.dp)
             )
         }
 
+        // Title and subtitle text
         Column(
             modifier = Modifier.weight(1f),
             verticalArrangement = Arrangement.spacedBy(4.dp)
@@ -198,15 +217,18 @@ private fun ThemeSwitchRow(
                 text = title,
                 fontSize = 13.sp,
                 fontWeight = FontWeight.Medium,
+                // Muted when disabled
                 color = if (enabled) colorScheme.onSurface else colorScheme.onSurfaceVariant.copy(alpha = 0.65f)
             )
             Text(
                 text = subtitle,
                 fontSize = 11.sp,
+                // Muted when disabled
                 color = if (enabled) colorScheme.onSurfaceVariant else colorScheme.onSurfaceVariant.copy(alpha = 0.65f)
             )
         }
 
+        // Toggle switch - calls viewModel.setDarkModeEnabled() or setAdaptiveThemeEnabled()
         Switch(
             checked = checked,
             onCheckedChange = onCheckedChange,


### PR DESCRIPTION
This pull request adds comprehensive documentation and clarifying comments throughout the theme management codebase. The changes make it much easier to understand how theme preferences, adaptive theme logic, and UI interactions work together. The most important changes are grouped by theme below.

**Documentation and Code Clarity Improvements:**

* Added detailed KDoc and inline comments to `MainActivity`, `ThemeSettingsViewModel`, `ThemePreferencesRepository`, `AmbientLightMonitor`, and the UI theme screen, explaining the flow of theme preferences, adaptive theme logic, and how the UI responds to changes. [[1]](diffhunk://#diff-f0cc9fd90049a847d0da02e312aad727603b68eebc395a8bb4c5f3e50d8c069eR18-R44) [[2]](diffhunk://#diff-2a684f8dd8d80eb94805376beac020eeebb2d5c51afb99dd40d37b50c748be80R13-R14) [[3]](diffhunk://#diff-2a684f8dd8d80eb94805376beac020eeebb2d5c51afb99dd40d37b50c748be80R23-R83) [[4]](diffhunk://#diff-01c546281fab84bf34a507499a1da7b2a08e3a8c6951dcca2be1bf3445f13534R13-R87) [[5]](diffhunk://#diff-01c546281fab84bf34a507499a1da7b2a08e3a8c6951dcca2be1bf3445f13534R96-R104) [[6]](diffhunk://#diff-651feca781a39da0a5fb74c08d2915258e3448874ff1698ba3194540b48f2edaR16-R79) [[7]](diffhunk://#diff-58f01c3fc7c727567806b6c772dd943caf57149697df171500329ba2ecf57378R47-R60) [[8]](diffhunk://#diff-58f01c3fc7c727567806b6c772dd943caf57149697df171500329ba2ecf57378R76) [[9]](diffhunk://#diff-58f01c3fc7c727567806b6c772dd943caf57149697df171500329ba2ecf57378R128) [[10]](diffhunk://#diff-58f01c3fc7c727567806b6c772dd943caf57149697df171500329ba2ecf57378R139-R145) [[11]](diffhunk://#diff-58f01c3fc7c727567806b6c772dd943caf57149697df171500329ba2ecf57378R155) [[12]](diffhunk://#diff-58f01c3fc7c727567806b6c772dd943caf57149697df171500329ba2ecf57378R171-R174) [[13]](diffhunk://#diff-58f01c3fc7c727567806b6c772dd943caf57149697df171500329ba2ecf57378R193-R211) [[14]](diffhunk://#diff-58f01c3fc7c727567806b6c772dd943caf57149697df171500329ba2ecf57378R220-R231)

**Theme Management Logic Explanations:**

* Clarified how theme preferences are persisted, read, and exposed as reactive flows in `ThemePreferencesRepository`, including the use of SharedPreferences keys and default values. [[1]](diffhunk://#diff-01c546281fab84bf34a507499a1da7b2a08e3a8c6951dcca2be1bf3445f13534R13-R87) [[2]](diffhunk://#diff-01c546281fab84bf34a507499a1da7b2a08e3a8c6951dcca2be1bf3445f13534R96-R104)
* Documented the adaptive theme logic in `ThemeSettingsViewModel`, including how sensor data and user preferences are combined to compute the effective theme. [[1]](diffhunk://#diff-2a684f8dd8d80eb94805376beac020eeebb2d5c51afb99dd40d37b50c748be80R13-R14) [[2]](diffhunk://#diff-2a684f8dd8d80eb94805376beac020eeebb2d5c51afb99dd40d37b50c748be80R23-R83)

**Ambient Light Sensor Handling:**

* Added explanatory comments to `AmbientLightMonitor` describing how the ambient light sensor is monitored, how readings are emitted, and how battery usage is managed.

**UI and User Interaction:**

* Improved comments in the theme settings UI screen and reusable toggle row, explaining how toggles interact with the view model and how UI elements are enabled/disabled based on state. [[1]](diffhunk://#diff-58f01c3fc7c727567806b6c772dd943caf57149697df171500329ba2ecf57378R47-R60) [[2]](diffhunk://#diff-58f01c3fc7c727567806b6c772dd943caf57149697df171500329ba2ecf57378R76) [[3]](diffhunk://#diff-58f01c3fc7c727567806b6c772dd943caf57149697df171500329ba2ecf57378R128) [[4]](diffhunk://#diff-58f01c3fc7c727567806b6c772dd943caf57149697df171500329ba2ecf57378R139-R145) [[5]](diffhunk://#diff-58f01c3fc7c727567806b6c772dd943caf57149697df171500329ba2ecf57378R155) [[6]](diffhunk://#diff-58f01c3fc7c727567806b6c772dd943caf57149697df171500329ba2ecf57378R171-R174) [[7]](diffhunk://#diff-58f01c3fc7c727567806b6c772dd943caf57149697df171500329ba2ecf57378R193-R211) [[8]](diffhunk://#diff-58f01c3fc7c727567806b6c772dd943caf57149697df171500329ba2ecf57378R220-R231)

These changes greatly enhance maintainability and onboarding for future developers by making the theme system's behavior and structure transparent.

Closes #92 