### PR TITLE
local storage + evc for user info

### DIFF
--- a/app/src/main/java/com/wheels/app/core/di/RepositoryModule.kt
+++ b/app/src/main/java/com/wheels/app/core/di/RepositoryModule.kt
@@ -27,6 +27,8 @@ import com.wheels.app.features.auth.domain.repository.AuthRepository
 import com.wheels.app.features.payments.domain.repository.PaymentRepository
 import com.wheels.app.features.rides.domain.repository.CancellationBehaviorRepository
 import com.wheels.app.features.rides.domain.repository.RideRepository
+import com.wheels.app.features.profile.data.repository.FirebaseUserProfileRepository
+import com.wheels.app.features.profile.domain.repository.UserProfileRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -70,6 +72,12 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindAuthRepository(impl: AuthRepositoryImpl): AuthRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindUserProfileRepository(
+        impl: FirebaseUserProfileRepository
+    ): UserProfileRepository
 
     @Binds
     @Singleton

--- a/app/src/main/java/com/wheels/app/features/auth/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/wheels/app/features/auth/data/repository/AuthRepositoryImpl.kt
@@ -18,6 +18,7 @@ import com.wheels.app.features.auth.domain.model.ForgotPasswordRequest
 import com.wheels.app.features.auth.domain.model.SignInRequest
 import com.wheels.app.features.auth.domain.repository.AuthRepository
 import com.wheels.app.features.auth.domain.util.buildInstitutionalEmail
+import com.wheels.app.features.profile.data.local.UserProfileLocalDataSource
 import com.wheels.app.features.profile.domain.model.User
 import java.util.Collections
 import javax.inject.Inject
@@ -38,6 +39,7 @@ import kotlinx.coroutines.withContext
 class AuthRepositoryImpl @Inject constructor(
     private val firebaseAuth: FirebaseAuth,
     private val firestore: FirebaseFirestore,
+    private val userProfileLocalDataSource: UserProfileLocalDataSource,
     private val ioDispatcher: CoroutineDispatcher
 ) : AuthRepository {
 
@@ -77,8 +79,11 @@ class AuthRepositoryImpl @Inject constructor(
             val refreshedUser = firebaseAuth.currentUser ?: return@runCatching null
             resolveAuthUser(refreshedUser)
         }.getOrElse {
-            firebaseAuth.signOut()
-            null
+            resolveAuthUser(currentUser)
+        }.also { authUser ->
+            if (authUser != null) {
+                cacheProfile(authUser)
+            }
         }
     }
 
@@ -129,6 +134,7 @@ class AuthRepositoryImpl @Inject constructor(
                 }
 
                 loginHistoryTimestamps.add(System.currentTimeMillis())
+                cacheProfile(authUser)
                 authUser
             }.fold(
                 onSuccess = { Resource.Success(it) },
@@ -151,6 +157,7 @@ class AuthRepositoryImpl @Inject constructor(
 
                 resolveAuthUser(firebaseUser).also {
                     loginHistoryTimestamps.add(System.currentTimeMillis())
+                    cacheProfile(it)
                 }
             }.fold(
                 onSuccess = { Resource.Success(it) },
@@ -218,7 +225,7 @@ class AuthRepositoryImpl @Inject constructor(
                     activeRole = role
                 )
 
-                resolveAuthUser(currentUser)
+                resolveAuthUser(currentUser).also { cacheProfile(it) }
             }.fold(
                 onSuccess = { Resource.Success(it) },
                 onFailure = { Resource.Error(it.toAuthFailure().message) }
@@ -251,7 +258,7 @@ class AuthRepositoryImpl @Inject constructor(
                     activeRole = role
                 )
 
-                resolveAuthUser(currentUser)
+                resolveAuthUser(currentUser).also { cacheProfile(it) }
             }.fold(
                 onSuccess = { Resource.Success(it) },
                 onFailure = { Resource.Error(it.toAuthFailure().message) }
@@ -262,6 +269,7 @@ class AuthRepositoryImpl @Inject constructor(
     override suspend fun signOut() {
         withContext(ioDispatcher) {
             firebaseAuth.signOut()
+            userProfileLocalDataSource.clearProfile()
         }
     }
 
@@ -304,6 +312,12 @@ class AuthRepositoryImpl @Inject constructor(
             roles = resolvedRoles,
             activeRole = activeRole
         )
+    }
+
+    private suspend fun cacheProfile(authUser: AuthUser) {
+        runCatching {
+            userProfileLocalDataSource.saveProfile(authUser.toProfileUser())
+        }
     }
 
     private fun com.google.firebase.firestore.DocumentSnapshot?.resolveStoredRoles(): Set<UserRole> {

--- a/app/src/main/java/com/wheels/app/features/profile/data/local/UserProfileLocalDataSource.kt
+++ b/app/src/main/java/com/wheels/app/features/profile/data/local/UserProfileLocalDataSource.kt
@@ -1,0 +1,96 @@
+package com.wheels.app.features.profile.data.local
+
+import android.content.Context
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.doublePreferencesKey
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.wheels.app.core.session.UserRole
+import com.wheels.app.features.profile.domain.model.User
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+
+private val Context.userProfileDataStore by preferencesDataStore(name = "user_profile_cache")
+
+@Singleton
+class UserProfileLocalDataSource @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    val cachedProfile: Flow<User?> = context.userProfileDataStore.data
+        .catch { exception ->
+            if (exception is IOException) {
+                emit(emptyPreferences())
+            } else {
+                throw exception
+            }
+        }
+        .map { preferences -> preferences.toUserOrNull() }
+
+    suspend fun saveProfile(user: User) {
+        context.userProfileDataStore.edit { preferences ->
+            preferences[Keys.ID] = user.id
+            preferences[Keys.FULL_NAME] = user.fullName
+            preferences[Keys.EMAIL] = user.email
+            preferences[Keys.PHONE] = user.phone
+            preferences[Keys.CREATED_AT_MILLIS] = user.createdAtMillis ?: -1L
+            preferences[Keys.UNIVERSITY_ID] = user.universityId
+            preferences[Keys.RATING] = user.rating
+            preferences[Keys.RIDES_COMPLETED] = user.ridesCompleted.toLong()
+            preferences[Keys.ROLES] = user.roles.joinToString(",") { it.storageValue }
+            preferences[Keys.ACTIVE_ROLE] = user.activeRole.storageValue
+        }
+    }
+
+    suspend fun clearProfile() {
+        context.userProfileDataStore.edit { it.clear() }
+    }
+
+    private fun Preferences.toUserOrNull(): User? {
+        val id = this[Keys.ID].orEmpty()
+        if (id.isBlank()) return null
+
+        val roles = this[Keys.ROLES]
+            .orEmpty()
+            .split(",")
+            .mapNotNull { value -> UserRole.fromStorageValue(value.trim()) }
+            .toSet()
+            .ifEmpty { setOf(UserRole.PASSENGER) }
+
+        return User(
+            id = id,
+            fullName = this[Keys.FULL_NAME].orEmpty(),
+            email = this[Keys.EMAIL].orEmpty(),
+            phone = this[Keys.PHONE].orEmpty(),
+            createdAtMillis = this[Keys.CREATED_AT_MILLIS]
+                ?.takeIf { it >= 0L },
+            universityId = this[Keys.UNIVERSITY_ID].orEmpty(),
+            rating = this[Keys.RATING] ?: 0.0,
+            ridesCompleted = (this[Keys.RIDES_COMPLETED] ?: 0L).toInt(),
+            roles = roles,
+            activeRole = UserRole.fromStorageValue(this[Keys.ACTIVE_ROLE])
+                ?.takeIf { it in roles }
+                ?: roles.first()
+        )
+    }
+
+    private companion object Keys {
+        val ID = stringPreferencesKey("id")
+        val FULL_NAME = stringPreferencesKey("full_name")
+        val EMAIL = stringPreferencesKey("email")
+        val PHONE = stringPreferencesKey("phone")
+        val CREATED_AT_MILLIS = longPreferencesKey("created_at_millis")
+        val UNIVERSITY_ID = stringPreferencesKey("university_id")
+        val RATING = doublePreferencesKey("rating")
+        val RIDES_COMPLETED = longPreferencesKey("rides_completed")
+        val ROLES = stringPreferencesKey("roles")
+        val ACTIVE_ROLE = stringPreferencesKey("active_role")
+    }
+}

--- a/app/src/main/java/com/wheels/app/features/profile/data/local/UserProfileLocalDataSource.kt
+++ b/app/src/main/java/com/wheels/app/features/profile/data/local/UserProfileLocalDataSource.kt
@@ -24,6 +24,7 @@ private val Context.userProfileDataStore by preferencesDataStore(name = "user_pr
 class UserProfileLocalDataSource @Inject constructor(
     @ApplicationContext private val context: Context
 ) {
+    // DataStore emits the last saved profile so the UI can render without network access.
     val cachedProfile: Flow<User?> = context.userProfileDataStore.data
         .catch { exception ->
             if (exception is IOException) {
@@ -35,6 +36,7 @@ class UserProfileLocalDataSource @Inject constructor(
         .map { preferences -> preferences.toUserOrNull() }
 
     suspend fun saveProfile(user: User) {
+        // Keep the latest profile fields on disk so the app can restore them after reconnecting.
         context.userProfileDataStore.edit { preferences ->
             preferences[Keys.ID] = user.id
             preferences[Keys.FULL_NAME] = user.fullName
@@ -50,6 +52,7 @@ class UserProfileLocalDataSource @Inject constructor(
     }
 
     suspend fun clearProfile() {
+        // Remove only the profile cache, not the rest of the app state.
         context.userProfileDataStore.edit { it.clear() }
     }
 
@@ -57,6 +60,7 @@ class UserProfileLocalDataSource @Inject constructor(
         val id = this[Keys.ID].orEmpty()
         if (id.isBlank()) return null
 
+        // Rebuild the domain model from primitive DataStore values.
         val roles = this[Keys.ROLES]
             .orEmpty()
             .split(",")

--- a/app/src/main/java/com/wheels/app/features/profile/data/repository/FirebaseUserProfileRepository.kt
+++ b/app/src/main/java/com/wheels/app/features/profile/data/repository/FirebaseUserProfileRepository.kt
@@ -1,0 +1,141 @@
+package com.wheels.app.features.profile.data.repository
+
+import com.google.android.gms.tasks.Task
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.firestore.FirebaseFirestore
+import com.wheels.app.core.network.NetworkMonitor
+import com.wheels.app.core.session.UserRole
+import com.wheels.app.features.profile.data.local.UserProfileLocalDataSource
+import com.wheels.app.features.profile.domain.model.User
+import com.wheels.app.features.profile.domain.repository.UserProfileRepository
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+@Singleton
+class FirebaseUserProfileRepository @Inject constructor(
+    private val firebaseAuth: FirebaseAuth,
+    private val firestore: FirebaseFirestore,
+    private val networkMonitor: NetworkMonitor,
+    private val localDataSource: UserProfileLocalDataSource,
+    private val ioDispatcher: CoroutineDispatcher
+) : UserProfileRepository {
+
+    override fun observeCurrentUserProfile(): Flow<User?> {
+        return callbackFlow {
+            val currentUser = firebaseAuth.currentUser
+            if (currentUser == null) {
+                trySend(null)
+                close()
+                return@callbackFlow
+            }
+
+            val localJob = launch {
+                localDataSource.cachedProfile.collect { cachedProfile ->
+                    trySend(cachedProfile)
+                }
+            }
+
+            if (networkMonitor.isOnline()) {
+                launch {
+                    val freshProfile = runCatching { fetchCurrentProfile(currentUser) }.getOrNull()
+                    if (freshProfile != null) {
+                        localDataSource.saveProfile(freshProfile)
+                    }
+                }
+            }
+
+            awaitClose {
+                localJob.cancel()
+            }
+        }.flowOn(ioDispatcher)
+    }
+
+    override suspend fun refreshCurrentUserProfile() {
+        withContext(ioDispatcher) {
+            val currentUser = firebaseAuth.currentUser ?: return@withContext
+            if (!networkMonitor.isOnline()) return@withContext
+
+            runCatching { fetchCurrentProfile(currentUser) }
+                .getOrNull()
+                ?.let { localDataSource.saveProfile(it) }
+        }
+    }
+
+    override suspend fun clearCachedProfile() {
+        withContext(ioDispatcher) {
+            localDataSource.clearProfile()
+        }
+    }
+
+    private suspend fun fetchCurrentProfile(firebaseUser: FirebaseUser): User {
+        val snapshot = firestore.collection(USERS_COLLECTION)
+            .document(firebaseUser.uid)
+            .get()
+            .awaitResult()
+
+        val roles = snapshot.resolveStoredRoles()
+        val activeRole = snapshot.resolveActiveRole(roles)
+
+        return User(
+            id = firebaseUser.uid,
+            fullName = snapshot.getString("fullName")
+                .orEmpty()
+                .ifBlank { firebaseUser.displayName.orEmpty() },
+            email = snapshot.getString("email")
+                ?: firebaseUser.email.orEmpty(),
+            phone = snapshot.getString("phone").orEmpty(),
+            createdAtMillis = snapshot.getTimestamp("createdAt")?.toDate()?.time,
+            universityId = snapshot.getString("universityId")
+                ?: firebaseUser.email.orEmpty().substringBefore("@").uppercase(Locale.getDefault()),
+            rating = snapshot.getDouble("rating") ?: 0.0,
+            ridesCompleted = snapshot.getLong("ridesCompleted")?.toInt() ?: 0,
+            roles = roles,
+            activeRole = activeRole
+        )
+    }
+
+    private fun com.google.firebase.firestore.DocumentSnapshot.resolveStoredRoles(): Set<UserRole> {
+        val explicitRoles = get("roles")
+            ?.let { raw -> raw as? List<*> }
+            ?.mapNotNull { UserRole.fromStorageValue(it as? String) }
+            ?.toSet()
+            .orEmpty()
+
+        if (explicitRoles.isNotEmpty()) return explicitRoles
+
+        return setOf(UserRole.fromStorageValue(getString("role")) ?: UserRole.PASSENGER)
+    }
+
+    private fun com.google.firebase.firestore.DocumentSnapshot.resolveActiveRole(
+        roles: Set<UserRole>
+    ): UserRole {
+        val explicitActiveRole = UserRole.fromStorageValue(getString("activeRole"))
+        return when {
+            explicitActiveRole != null && explicitActiveRole in roles -> explicitActiveRole
+            UserRole.PASSENGER in roles -> UserRole.PASSENGER
+            else -> roles.firstOrNull() ?: UserRole.PASSENGER
+        }
+    }
+
+    private suspend fun <T> Task<T>.awaitResult(): T {
+        return kotlinx.coroutines.suspendCancellableCoroutine { continuation ->
+            addOnSuccessListener { result -> continuation.resume(result) }
+            addOnFailureListener { exception -> continuation.resumeWithException(exception) }
+        }
+    }
+
+    private companion object {
+        const val USERS_COLLECTION = "users"
+    }
+}

--- a/app/src/main/java/com/wheels/app/features/profile/data/repository/FirebaseUserProfileRepository.kt
+++ b/app/src/main/java/com/wheels/app/features/profile/data/repository/FirebaseUserProfileRepository.kt
@@ -32,7 +32,9 @@ class FirebaseUserProfileRepository @Inject constructor(
 ) : UserProfileRepository {
 
     override fun observeCurrentUserProfile(): Flow<User?> {
+        // callbackFlow lets us combine the cached stream with an optional remote refresh.
         return callbackFlow {
+            // No authenticated user means there is no profile stream to expose.
             val currentUser = firebaseAuth.currentUser
             if (currentUser == null) {
                 trySend(null)
@@ -40,12 +42,14 @@ class FirebaseUserProfileRepository @Inject constructor(
                 return@callbackFlow
             }
 
+            // Replay the cached profile first so the UI still works while offline or loading.
             val localJob = launch {
                 localDataSource.cachedProfile.collect { cachedProfile ->
                     trySend(cachedProfile)
                 }
             }
 
+            // When connectivity is available, refresh Firestore and persist the newest data locally.
             if (networkMonitor.isOnline()) {
                 launch {
                     val freshProfile = runCatching { fetchCurrentProfile(currentUser) }.getOrNull()
@@ -56,6 +60,7 @@ class FirebaseUserProfileRepository @Inject constructor(
             }
 
             awaitClose {
+                // Stop collecting the cache stream when the UI no longer needs updates.
                 localJob.cancel()
             }
         }.flowOn(ioDispatcher)
@@ -66,6 +71,7 @@ class FirebaseUserProfileRepository @Inject constructor(
             val currentUser = firebaseAuth.currentUser ?: return@withContext
             if (!networkMonitor.isOnline()) return@withContext
 
+            // Manual refresh uses the same remote-to-cache path as the live observer.
             runCatching { fetchCurrentProfile(currentUser) }
                 .getOrNull()
                 ?.let { localDataSource.saveProfile(it) }
@@ -74,16 +80,19 @@ class FirebaseUserProfileRepository @Inject constructor(
 
     override suspend fun clearCachedProfile() {
         withContext(ioDispatcher) {
+            // Sign-out cleanup removes any stale profile that might belong to another account.
             localDataSource.clearProfile()
         }
     }
 
     private suspend fun fetchCurrentProfile(firebaseUser: FirebaseUser): User {
+        // Firestore is the source of truth when the app can reach the network.
         val snapshot = firestore.collection(USERS_COLLECTION)
             .document(firebaseUser.uid)
             .get()
             .awaitResult()
 
+        // Merge Firestore fields with Firebase Auth fallbacks to avoid empty profile data.
         val roles = snapshot.resolveStoredRoles()
         val activeRole = snapshot.resolveActiveRole(roles)
 

--- a/app/src/main/java/com/wheels/app/features/profile/domain/model/User.kt
+++ b/app/src/main/java/com/wheels/app/features/profile/domain/model/User.kt
@@ -2,6 +2,7 @@ package com.wheels.app.features.profile.domain.model
 
 import com.wheels.app.core.session.UserRole
 
+// Immutable profile snapshot shared across remote fetch, local cache, and UI.
 data class User(
     val id: String,
     val fullName: String,
@@ -14,6 +15,7 @@ data class User(
     val roles: Set<UserRole>,
     val activeRole: UserRole
 ) {
+    // Convenience flag used when the UI needs to know if the user can drive.
     val isDriver: Boolean
         get() = UserRole.DRIVER in roles
 }

--- a/app/src/main/java/com/wheels/app/features/profile/domain/repository/UserProfileRepository.kt
+++ b/app/src/main/java/com/wheels/app/features/profile/domain/repository/UserProfileRepository.kt
@@ -1,0 +1,12 @@
+package com.wheels.app.features.profile.domain.repository
+
+import com.wheels.app.features.profile.domain.model.User
+import kotlinx.coroutines.flow.Flow
+
+interface UserProfileRepository {
+    fun observeCurrentUserProfile(): Flow<User?>
+
+    suspend fun refreshCurrentUserProfile()
+
+    suspend fun clearCachedProfile()
+}

--- a/app/src/main/java/com/wheels/app/features/profile/domain/repository/UserProfileRepository.kt
+++ b/app/src/main/java/com/wheels/app/features/profile/domain/repository/UserProfileRepository.kt
@@ -4,9 +4,12 @@ import com.wheels.app.features.profile.domain.model.User
 import kotlinx.coroutines.flow.Flow
 
 interface UserProfileRepository {
+    // Exposes the current profile as a reactive stream for offline-first UI updates.
     fun observeCurrentUserProfile(): Flow<User?>
 
+    // Forces a remote refresh and writes the result back into local cache.
     suspend fun refreshCurrentUserProfile()
 
+    // Clears the cached profile when the user signs out.
     suspend fun clearCachedProfile()
 }

--- a/app/src/main/java/com/wheels/app/features/profile/domain/usecase/GetUserProfileUseCase.kt
+++ b/app/src/main/java/com/wheels/app/features/profile/domain/usecase/GetUserProfileUseCase.kt
@@ -1,12 +1,12 @@
 package com.wheels.app.features.profile.domain.usecase
 
 import com.wheels.app.features.profile.domain.model.User
-import com.wheels.app.features.auth.domain.repository.AuthRepository
+import com.wheels.app.features.profile.domain.repository.UserProfileRepository
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class GetUserProfileUseCase @Inject constructor(
-    private val authRepository: AuthRepository
+    private val userProfileRepository: UserProfileRepository
 ) {
-    operator fun invoke(): Flow<User?> = authRepository.getCurrentUser()
+    operator fun invoke(): Flow<User?> = userProfileRepository.observeCurrentUserProfile()
 }

--- a/app/src/main/java/com/wheels/app/features/profile/domain/usecase/GetUserProfileUseCase.kt
+++ b/app/src/main/java/com/wheels/app/features/profile/domain/usecase/GetUserProfileUseCase.kt
@@ -8,5 +8,6 @@ import javax.inject.Inject
 class GetUserProfileUseCase @Inject constructor(
     private val userProfileRepository: UserProfileRepository
 ) {
+    // Domain layer stays independent from Firebase and DataStore details.
     operator fun invoke(): Flow<User?> = userProfileRepository.observeCurrentUserProfile()
 }

--- a/app/src/main/java/com/wheels/app/features/profile/presentation/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/com/wheels/app/features/profile/presentation/viewmodel/ProfileViewModel.kt
@@ -80,6 +80,7 @@ class ProfileViewModel @Inject constructor(
 
     private fun observeProfile() {
         viewModelScope.launch {
+            // Keep profile data, active role, and available roles in one UI stream.
             combine(
                 getUserProfileUseCase().catch { emit(null) },
                 roleManager.activeRole,
@@ -89,6 +90,7 @@ class ProfileViewModel @Inject constructor(
             }.collect { (user, activeRole, availableRoles) ->
                 if (user == null) {
                     observedTrustUserId = null
+                    // Use safe placeholders until the cached or remote profile becomes available.
                     _uiState.value = _uiState.value.copy(
                         isLoading = false,
                         name = "Estudiante Uniandes",
@@ -105,6 +107,7 @@ class ProfileViewModel @Inject constructor(
                     )
                 } else {
                     val displayName = user.fullName.ifBlank {
+                        // Fall back to the email prefix when the backend does not provide a name.
                         user.email.substringBefore("@")
                             .replace('.', ' ')
                             .ifBlank { "Estudiante Uniandes" }
@@ -133,6 +136,7 @@ class ProfileViewModel @Inject constructor(
 
     private fun observeTrustScore(userId: String) {
         viewModelScope.launch {
+            // Trust score is loaded separately so failures do not block the profile screen.
             driverTrustRepository.observeDriverTrustScore(userId)
                 .catch {
                     _uiState.value = _uiState.value.copy(trustScoreLoading = false)
@@ -147,6 +151,7 @@ class ProfileViewModel @Inject constructor(
     }
 
     private fun switchRole(role: UserRole) {
+        // Role switches are gated by connectivity because they depend on remote auth state.
         if (!networkMonitor.isOnline()) {
             _uiState.value = _uiState.value.copy(
                 roleActionLoading = false,
@@ -202,6 +207,7 @@ class ProfileViewModel @Inject constructor(
         val password = _uiState.value.roleUpgradePassword
         val previousRole = _uiState.value.activeRole
 
+        // Upgrading a role also requires the server, so we fail fast when offline.
         if (!networkMonitor.isOnline()) {
             _uiState.value = _uiState.value.copy(
                 roleActionLoading = false,

--- a/app/src/main/java/com/wheels/app/features/profile/presentation/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/com/wheels/app/features/profile/presentation/viewmodel/ProfileViewModel.kt
@@ -104,9 +104,15 @@ class ProfileViewModel @Inject constructor(
                         roleInfoMessage = null
                     )
                 } else {
+                    val displayName = user.fullName.ifBlank {
+                        user.email.substringBefore("@")
+                            .replace('.', ' ')
+                            .ifBlank { "Estudiante Uniandes" }
+                    }
+
                     _uiState.value = _uiState.value.copy(
                         isLoading = false,
-                        name = user.fullName,
+                        name = displayName,
                         email = user.email,
                         phone = user.phone,
                         memberSinceLabel = formatMemberSince(user.createdAtMillis),


### PR DESCRIPTION
This pull request introduces a local caching layer for user profiles and refactors how user profile data is accessed and managed throughout the app. The key changes include the creation of a `UserProfileLocalDataSource`, a new repository abstraction for user profiles, and updates to authentication and profile features to leverage these improvements.

**User Profile Caching and Repository Abstraction:**

* Added `UserProfileLocalDataSource` to handle local caching of user profile data using DataStore, including methods to save, clear, and observe cached profiles.
* Introduced `UserProfileRepository` interface and its implementation `FirebaseUserProfileRepository`, which coordinates between Firebase, network state, and the local cache for profile data. [[1]](diffhunk://#diff-34e5668909b291bafc9b2c9a1b327d50fadc017cc3c7633ddfc4371550d67821R1-R12) [[2]](diffhunk://#diff-b567315355ec0b9dbc291b48f9cfdb3d88dff6b0b83a57921610a9f61747758bR1-R141)
* Updated dependency injection in `RepositoryModule` to provide the new repository and its dependencies. [[1]](diffhunk://#diff-e3b799fcacc2f039a9339be4fbc5f8aefbb953c064a35bb99d12fa493308c6c5R30-R31) [[2]](diffhunk://#diff-e3b799fcacc2f039a9339be4fbc5f8aefbb953c064a35bb99d12fa493308c6c5R76-R81)

**Authentication Integration with Profile Caching:**

* Modified `AuthRepositoryImpl` to cache user profiles locally on authentication events (sign-in, role change, etc.) and to clear the cache on sign-out. [[1]](diffhunk://#diff-e1d8d81e49303aea2583509bde2d6b2bf9fce3e664d8c9e074b2884bb358f05eR21) [[2]](diffhunk://#diff-e1d8d81e49303aea2583509bde2d6b2bf9fce3e664d8c9e074b2884bb358f05eR42) [[3]](diffhunk://#diff-e1d8d81e49303aea2583509bde2d6b2bf9fce3e664d8c9e074b2884bb358f05eL80-R86) [[4]](diffhunk://#diff-e1d8d81e49303aea2583509bde2d6b2bf9fce3e664d8c9e074b2884bb358f05eR137) [[5]](diffhunk://#diff-e1d8d81e49303aea2583509bde2d6b2bf9fce3e664d8c9e074b2884bb358f05eR160) [[6]](diffhunk://#diff-e1d8d81e49303aea2583509bde2d6b2bf9fce3e664d8c9e074b2884bb358f05eL221-R228) [[7]](diffhunk://#diff-e1d8d81e49303aea2583509bde2d6b2bf9fce3e664d8c9e074b2884bb358f05eL254-R261) [[8]](diffhunk://#diff-e1d8d81e49303aea2583509bde2d6b2bf9fce3e664d8c9e074b2884bb358f05eR272) [[9]](diffhunk://#diff-e1d8d81e49303aea2583509bde2d6b2bf9fce3e664d8c9e074b2884bb358f05eR317-R322)

**Profile Feature Refactoring:**

* Refactored `GetUserProfileUseCase` to use the new `UserProfileRepository` instead of directly accessing the authentication repository.
* Improved display logic in `ProfileViewModel` to generate a fallback display name if the user's full name is blank.

Closes #95 