### PR TITLE
feat: Add auto-sync on reconnect for BQT3 and BQ13

### DIFF
--- a/app/src/main/java/com/wheels/app/core/analytics/bqt3/data/repository/BQT3RepositoryImpl.kt
+++ b/app/src/main/java/com/wheels/app/core/analytics/bqt3/data/repository/BQT3RepositoryImpl.kt
@@ -7,6 +7,7 @@ import com.wheels.app.core.analytics.bqt3.domain.model.BQT3_FEATURE_NAME
 import com.wheels.app.core.analytics.bqt3.domain.model.BQT3UsageEvent
 import com.wheels.app.core.analytics.bqt3.domain.model.BQT3WeeklyUsage
 import com.wheels.app.core.analytics.bqt3.domain.repository.BQT3Repository
+import com.wheels.app.core.network.NetworkMonitor
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
@@ -15,6 +16,9 @@ import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 @Singleton
@@ -22,8 +26,24 @@ class BQT3RepositoryImpl @Inject constructor(
     private val remoteDataSource: BQT3RemoteDataSource,
     private val localDataSource: BQT3LocalDataSource,
     private val connectivityChecker: ConnectivityChecker,
+    private val networkMonitor: NetworkMonitor,
     private val ioDispatcher: CoroutineDispatcher
 ) : BQT3Repository {
+
+    private val repositoryScope = CoroutineScope(ioDispatcher + SupervisorJob())
+
+    init {
+        repositoryScope.launch {
+            var wasOnline = false
+            networkMonitor.observeIsOnline().collect { isOnline ->
+                if (isOnline && !wasOnline) {
+                    // Transición de offline a online: sincronizar eventos pendientes
+                    syncPendingEvents()
+                }
+                wasOnline = isOnline
+            }
+        }
+    }
 
     override suspend fun trackRidesNearMeUsage(userId: String): BQT3WeeklyUsage {
         return withContext(ioDispatcher) {

--- a/app/src/main/java/com/wheels/app/core/analytics/data/repository/CachedUserDestinationInsightsRepository.kt
+++ b/app/src/main/java/com/wheels/app/core/analytics/data/repository/CachedUserDestinationInsightsRepository.kt
@@ -7,11 +7,15 @@ import com.wheels.app.core.network.NetworkMonitor
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -22,6 +26,30 @@ class CachedUserDestinationInsightsRepository @Inject constructor(
     private val networkMonitor: NetworkMonitor,
     private val ioDispatcher: CoroutineDispatcher
 ) : UserDestinationInsightsRepository {
+
+    private val repositoryScope = CoroutineScope(ioDispatcher + SupervisorJob())
+    private var lastRefreshedUserIds = mutableSetOf<String>()
+
+    init {
+        repositoryScope.launch {
+            var wasOnline = false
+            networkMonitor.observeIsOnline().collect { isOnline ->
+                if (isOnline && !wasOnline) {
+                    // Transición de offline a online: refrescar datos cacheados desde Firebase
+                    val userIdsToRefresh = lastRefreshedUserIds.toList()
+                    userIdsToRefresh.forEach { userId ->
+                        runCatching {
+                            val value = remote.observeUserDestinationInsights(userId).first()
+                            if (value != null) {
+                                local.saveSnapshot(value)
+                            }
+                        }
+                    }
+                }
+                wasOnline = isOnline
+            }
+        }
+    }
 
     override suspend fun logRideBookedDestination(userId: String, rideId: String, destinationName: String) {
         // Always attempt remote when online; if offline, still write to remote will fail — keep behavior as remote-only
@@ -35,6 +63,8 @@ class CachedUserDestinationInsightsRepository @Inject constructor(
 
     override fun observeUserDestinationInsights(userId: String): Flow<UserDestinationInsights?> =
         flow {
+            lastRefreshedUserIds.add(userId)  // Track this userId for future reconnections
+            
             val cached = withContext(ioDispatcher) { local.getCached(userId) }
             if (cached != null) emit(cached)
 


### PR DESCRIPTION
## Changes

### BQT3 (Rides Near Me Usage Tracking)
- **Auto-sync on reconnect**: Automatically synchronizes pending usage events to Firebase when connection is restored
- Observes network connectivity changes via `NetworkMonitor`
- Triggers `syncPendingEvents()` immediately on offline → online transition
- Prevents data loss for offline-recorded events

### BQ13 (Frequent Destinations)
- **Auto-refresh on reconnect**: Automatically refreshes frequent destinations snapshot from Firebase when connection is restored
- Tracks observed user IDs to efficiently refresh only relevant data
- Updates local cache with fresh data from Firestore
- Users see "Last updated" timestamp reflect the refresh

## Technical Details

### BQT3RepositoryImpl
- Added `NetworkMonitor` dependency
- Created `repositoryScope` with `CoroutineScope(ioDispatcher + SupervisorJob())`
- Observes `networkMonitor.observeIsOnline()` 
- Detects offline → online transition and calls `syncPendingEvents()`

### CachedUserDestinationInsightsRepository
- Added `lastRefreshedUserIds` set to track active user contexts
- Created `repositoryScope` to observe connectivity
- On reconnect, calls `.first()` on `remote.observeUserDestinationInsights()` for each tracked user
- Saves refreshed snapshot to local database via `local.saveSnapshot(value)`

## Testing
- ✅ Compilation successful (no errors)
- ✅ Firebase sync chain intact
- ✅ Local cache fallback still works
- ✅ Network observer properly integrated

## Related Issues
- Requirement: Auto-sync events and insights on network reconnection
- Affects: Offline-first data synchronization