### PR TITLE
fixes

### DIFF
--- a/app/src/main/java/com/wheels/app/features/rides/data/repository/RideRepositoryImpl.kt
+++ b/app/src/main/java/com/wheels/app/features/rides/data/repository/RideRepositoryImpl.kt
@@ -406,7 +406,7 @@ class RideRepositoryImpl @Inject constructor(
 
             for (pendingPublish in pendingPublishes) {
                 try {
-                    createRide(pendingPublish.toPublishRideRequest())
+                    publishRide(pendingPublish.toPublishRideRequest())
                     rideOfflineDao.deletePendingRidePublish(pendingPublish.id)
                     syncedCount += 1
                 } catch (throwable: Throwable) {

--- a/app/src/main/java/com/wheels/app/features/rides/presentation/viewmodel/RidesViewModel.kt
+++ b/app/src/main/java/com/wheels/app/features/rides/presentation/viewmodel/RidesViewModel.kt
@@ -892,18 +892,27 @@ class RidesViewModel @Inject constructor(
             time = currentState.time
         ) ?: return showTrustError("We could not parse the selected ride schedule.")
         val estimatedDurationMinutes = 30
+        val isOnline = networkMonitor.isOnline()
 
         viewModelScope.launch {
             _uiState.update { state -> state.copy(isPublishingRide = true) }
             runCatching {
-                val originCoordinates = resolveCoordinatesForPublish(
-                    typedValue = currentState.origin,
-                    selectedSuggestion = currentState.selectedOrigin
-                )
-                val destinationCoordinates = resolveCoordinatesForPublish(
-                    typedValue = currentState.destination,
-                    selectedSuggestion = currentState.selectedDestination
-                )
+                val originCoordinates = if (isOnline) {
+                    resolveCoordinatesForPublish(
+                        typedValue = currentState.origin,
+                        selectedSuggestion = currentState.selectedOrigin
+                    )
+                } else {
+                    currentState.selectedOrigin?.coordinates
+                }
+                val destinationCoordinates = if (isOnline) {
+                    resolveCoordinatesForPublish(
+                        typedValue = currentState.destination,
+                        selectedSuggestion = currentState.selectedDestination
+                    )
+                } else {
+                    currentState.selectedDestination?.coordinates
+                }
 
                 val request = PublishRideRequest(
                     driverId = driverId,
@@ -931,12 +940,21 @@ class RidesViewModel @Inject constructor(
                     usedCurrentLocationDestination = currentState.usedCurrentLocationDestination
                 )
 
-                rideRepository.createRide(request)
+                if (isOnline) {
+                    rideRepository.publishRide(request)
+                } else {
+                    rideRepository.enqueueRidePublish(request)
+                    null
+                }
             }.onSuccess {
                 rideRepository.clearCreateRideDraft(driverId)
                 _uiState.update { state ->
                     state.resetCreateRideForm(
-                        publishRideInfoMessage = "Ride published successfully."
+                        publishRideInfoMessage = if (isOnline) {
+                            "Ride published successfully."
+                        } else {
+                            "No internet connection. We saved your ride and will publish it automatically when your connection returns."
+                        }
                     )
                 }
             }.onFailure { throwable ->
@@ -1062,6 +1080,20 @@ class RidesViewModel @Inject constructor(
         if (ride.status != DriverRideStatus.ACTIVE) {
             return showTrustError("Only active rides can be completed.")
         }
+        if (ride.pendingSyncAction != null) {
+            return showTrustError("This ride already has a pending offline action. Wait for the connection to return before sending another one.")
+        }
+        val driverId = currentDriverId ?: return showTrustError("No signed-in driver is available.")
+        val isOnline = networkMonitor.isOnline()
+        if (!isOnline) {
+            enqueueOfflineRideAction(
+                ride = ride,
+                driverId = driverId,
+                actionType = PendingRideActionType.COMPLETE,
+                infoMessage = "No internet connection. We saved your end ride action and will complete this ride automatically when your connection returns."
+            )
+            return
+        }
         viewModelScope.launch {
             _uiState.update { state -> state.copy(actionInProgressRideId = rideId) }
             runCatching {
@@ -1103,6 +1135,20 @@ class RidesViewModel @Inject constructor(
         if (ride.status != DriverRideStatus.PUBLISHED) {
             return showTrustError("Only published rides can be started.")
         }
+        if (ride.pendingSyncAction != null) {
+            return showTrustError("This ride already has a pending offline action. Wait for the connection to return before sending another one.")
+        }
+        val driverId = currentDriverId ?: return showTrustError("No signed-in driver is available.")
+        val isOnline = networkMonitor.isOnline()
+        if (!isOnline) {
+            enqueueOfflineRideAction(
+                ride = ride,
+                driverId = driverId,
+                actionType = PendingRideActionType.START,
+                infoMessage = "No internet connection. We saved your start ride action and will start this ride automatically when your connection returns."
+            )
+            return
+        }
         viewModelScope.launch {
             _uiState.update { state -> state.copy(actionInProgressRideId = rideId) }
             runCatching {
@@ -1133,6 +1179,20 @@ class RidesViewModel @Inject constructor(
         val ride = _uiState.value.driverRides.firstOrNull { it.id == rideId } ?: return
         if (ride.status != DriverRideStatus.PUBLISHED && ride.status != DriverRideStatus.ACTIVE) {
             return showTrustError("Only open or active rides can be canceled from this screen.")
+        }
+        if (ride.pendingSyncAction != null) {
+            return showTrustError("This ride already has a pending offline action. Wait for the connection to return before sending another one.")
+        }
+        val driverId = currentDriverId ?: return showTrustError("No signed-in driver is available.")
+        val isOnline = networkMonitor.isOnline()
+        if (!isOnline) {
+            enqueueOfflineRideAction(
+                ride = ride,
+                driverId = driverId,
+                actionType = PendingRideActionType.CANCEL,
+                infoMessage = "No internet connection. We saved your cancel ride action and will cancel this ride automatically when your connection returns."
+            )
+            return
         }
 
         viewModelScope.launch {


### PR DESCRIPTION
This pull request introduces robust offline support for ride publishing and ride actions (start, complete, cancel). Now, when the user is offline, ride actions are queued and automatically synchronized when the connection is restored, and the UI provides clear feedback about these states. The logic for publishing rides and handling ride actions has been updated to check network status and queue actions as needed.

**Offline support for ride publishing:**
- When publishing a ride, the app now checks if the user is online. If offline, it saves the ride request locally and informs the user that the ride will be published automatically once the connection returns. The UI message is updated accordingly. (`RidesViewModel.kt` [[1]](diffhunk://#diff-b507e5a97dc0ccea3b9a5e2e87ef03f6d64da24bf5c9dd868bd961c4445ac547R895-R915) [[2]](diffhunk://#diff-b507e5a97dc0ccea3b9a5e2e87ef03f6d64da24bf5c9dd868bd961c4445ac547L934-R957)

**Offline support for ride actions (start, complete, cancel):**
- The app now checks for network connectivity and existing pending offline actions before allowing start, complete, or cancel actions on a ride. If offline, the action is queued and the user is notified it will be completed when back online. Duplicate offline actions are prevented. (`RidesViewModel.kt` [[1]](diffhunk://#diff-b507e5a97dc0ccea3b9a5e2e87ef03f6d64da24bf5c9dd868bd961c4445ac547R1083-R1096) [[2]](diffhunk://#diff-b507e5a97dc0ccea3b9a5e2e87ef03f6d64da24bf5c9dd868bd961c4445ac547R1138-R1151) [[3]](diffhunk://#diff-b507e5a97dc0ccea3b9a5e2e87ef03f6d64da24bf5c9dd868bd961c4445ac547R1183-R1196)

**Repository update for offline publishing:**
- The repository method for processing pending ride publishes now uses the correct method (`publishRide`) to ensure consistency with the new offline/online logic. (`RideRepositoryImpl.kt` [app/src/main/java/com/wheels/app/features/rides/data/repository/RideRepositoryImpl.ktL409-R409](diffhunk://#diff-a57999b719e5a8b6921167ed550589b11092a4d0c6689c92fe6f9475b4a43000L409-R409))